### PR TITLE
feat(cli): shell completion and document caching system

### DIFF
--- a/.changeset/jolly-heads-refuse.md
+++ b/.changeset/jolly-heads-refuse.md
@@ -1,0 +1,54 @@
+---
+'@hackersheet/cli': minor
+---
+
+## Major Features and Improvements
+
+### Shell Tab Completion System (Complete Implementation)
+- **Document Slug Completion**: Autocomplete document slugs with `docs show <TAB>`
+- **Document Title Display**: Show document titles in zsh/fish completion suggestions
+- **Workspace Auto-detection**: Support -w/--workspace option, default workspace, and single workspace auto-selection
+- **All Subcommand Completion**: Autocomplete subcommands for docs, config, completion, and cache commands
+- **Cursor-based Pagination**: Display all completion candidates in large document environments (100+)
+- **Metadata Cache**: Cache completion metadata in ~/.cache/hackersheet/slugs-cache.json
+
+### Setup/Init Command Separation
+- **`hscli setup`**: Configure global settings (workspace authentication) in ~/.config/hackersheet/cli.config.json
+- **`hscli init`**: Configure project settings (document directories, filename template) in .hackersheet/cli.config.json
+- **Mode-based Wizard**: Conditional prompting with ConfigWizardMode('global', 'project', 'all')
+- **Prerequisite Validation**: Validate setup execution in init/new commands with clear error messages
+- **Git-inspired Pattern**: Design follows Git's --global/--local pattern for familiarity
+
+### Docs Command Refactoring
+- **`docs list`**: Display all documents with pagination support
+- **`docs show <slug>`**: Display document content by slug
+- Improved CLI consistency and usability
+
+### Document Content Caching
+- **Persistent File-based Cache**: Store documents in ~/.cache/hackersheet/documents/{workspace}/{slug}.json
+- **Complete Document Metadata**: Cache id, slug, title, content, and draft status
+- **`--refresh` Flag**: Use `docs show <slug> --refresh` to bypass cache
+- **Performance Improvement**: ~4.7x faster for cached document retrieval (0.093s vs 0.436s)
+- **Cache Clearing**: `cache clear` removes all caches (slugs + documents)
+
+### Cache Directory Path Display
+- **`config path`**: Display configuration files and cache directory paths
+- **`-g, --global`**: Show only global configuration path
+- **`-l, --local`**: Show only project configuration path
+- **`-c, --cache`**: Show only cache directory path
+- XDG Base Directory Specification compliant
+
+## Testing & Quality Improvements
+
+- **New Test File**: `docs-show-action.unit.test.ts` (14 tests)
+- **Expanded Test Coverage**: Cache functionality, cache clear, comprehensive error handling
+- **Total Tests**: 370 passing
+- **TypeScript Checks**: All passing
+- **ESLint**: Clean
+
+## Architecture Improvements
+
+- **Separation of Concerns**: Clear distinction between global and project configuration
+- **Dependency Injection**: Improved testability with injectable dependencies
+- **Error Handling**: Prerequisite validation with user-friendly error messages
+- **XDG Compliance**: Standard ~/.cache and ~/.config directory usage

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@hackersheet/core": "workspace:*",
     "@inquirer/prompts": "^8.2.0",
+    "@pnpm/tabtab": "^0.1.0",
     "commander": "^14.0.3",
     "find-up": "^8.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/cli/src/@pnpm+tabtab.d.ts
+++ b/packages/cli/src/@pnpm+tabtab.d.ts
@@ -1,13 +1,46 @@
 declare module '@pnpm/tabtab' {
+  /**
+   * Represents a completion item with name and optional description.
+   * Description is shown in zsh and fish but not in bash.
+   */
+  export interface CompletionItem {
+    /** The completion text to be inserted. */
+    name: string;
+    /** Optional description shown in zsh/fish. */
+    description?: string;
+  }
+
+  /**
+   * Parsed environment from the shell during completion.
+   */
   export interface ParseEnvResult {
+    /** True if we are in completion mode. */
     complete?: boolean;
+    /** The full command line. */
     line: string;
+    /** The previous word typed. */
     prev: string;
   }
 
   const tabtab: {
+    /**
+     * Parse environment variables to determine completion context.
+     * @param env - process.env object
+     * @returns Parsed completion environment
+     */
     parseEnv: (env: NodeJS.ProcessEnv) => ParseEnvResult;
-    log: (items: string[]) => void;
+
+    /**
+     * Output completion suggestions to the shell.
+     * Accepts either string array (slugs) or completion items with descriptions.
+     * @param items - Array of completion strings or items
+     */
+    log: (items: string[] | CompletionItem[]) => void;
+
+    /**
+     * Install shell completion for this command.
+     * @param options - Installation options
+     */
     install: (options: { name: string; completer: string }) => Promise<void>;
   };
 

--- a/packages/cli/src/@pnpm+tabtab.d.ts
+++ b/packages/cli/src/@pnpm+tabtab.d.ts
@@ -1,0 +1,15 @@
+declare module '@pnpm/tabtab' {
+  export interface ParseEnvResult {
+    complete?: boolean;
+    line: string;
+    prev: string;
+  }
+
+  const tabtab: {
+    parseEnv: (env: NodeJS.ProcessEnv) => ParseEnvResult;
+    log: (items: string[]) => void;
+    install: (options: { name: string; completer: string }) => Promise<void>;
+  };
+
+  export default tabtab;
+}

--- a/packages/cli/src/__tests__/completion-handler.unit.test.ts
+++ b/packages/cli/src/__tests__/completion-handler.unit.test.ts
@@ -91,8 +91,8 @@ describe('completionHandler', () => {
   it('suggests document slugs for docs command', async () => {
     const mockParseEnv = vi.fn(() => ({
       complete: true,
-      line: 'hscli docs',
-      prev: 'docs',
+      line: 'hscli docs show',
+      prev: 'show',
     }));
     vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
 
@@ -136,8 +136,8 @@ describe('completionHandler', () => {
   it('uses cached documents when available', async () => {
     const mockParseEnv = vi.fn(() => ({
       complete: true,
-      line: 'hscli docs',
-      prev: 'docs',
+      line: 'hscli docs show',
+      prev: 'show',
     }));
     vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
 
@@ -169,7 +169,7 @@ describe('completionHandler', () => {
   it('uses specified workspace for docs completion', async () => {
     const mockParseEnv = vi.fn(() => ({
       complete: true,
-      line: 'hscli docs -w workspace-2',
+      line: 'hscli docs show -w workspace-2',
       prev: '',
     }));
     vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
@@ -204,8 +204,8 @@ describe('completionHandler', () => {
   it('returns empty array when API call fails', async () => {
     const mockParseEnv = vi.fn(() => ({
       complete: true,
-      line: 'hscli docs',
-      prev: 'docs',
+      line: 'hscli docs show',
+      prev: 'show',
     }));
     vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
 

--- a/packages/cli/src/__tests__/completion-handler.unit.test.ts
+++ b/packages/cli/src/__tests__/completion-handler.unit.test.ts
@@ -1,0 +1,279 @@
+import tabtab from '@pnpm/tabtab';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { completionHandler } from '../completion-handler';
+
+import type { Config } from '../utils/load-config';
+
+
+// Mock tabtab module
+vi.mock('@pnpm/tabtab', () => ({
+  default: {
+    parseEnv: vi.fn(),
+    log: vi.fn(),
+  },
+}));
+
+describe('completionHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockConfig: Config = {
+    workspaces: {
+      'workspace-1': {
+        accessKey: 'key1',
+      },
+      'workspace-2': {
+        accessKey: 'key2',
+      },
+    },
+    defaultWorkspace: 'workspace-1',
+    newFilenameTemplate: 'template',
+    docsDirs: [],
+  };
+
+  it('does nothing when not in completion mode', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: false,
+      line: 'hscli',
+      prev: 'hscli',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).not.toHaveBeenCalled();
+  });
+
+  it('suggests workspace slugs for --workspace option', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      prev: '--workspace',
+      line: 'hscli docs --workspace',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([
+      'workspace-1',
+      'workspace-2',
+    ]);
+  });
+
+  it('suggests workspace slugs for -w option', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      prev: '-w',
+      line: 'hscli docs -w',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([
+      'workspace-1',
+      'workspace-2',
+    ]);
+  });
+
+  it('suggests document slugs for docs command', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs',
+      prev: 'docs',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    const mockLoadCache = vi.fn(() => null);
+    const mockSaveCache = vi.fn().mockResolvedValue(undefined);
+    const mockCreateClient = vi.fn(() => ({
+      getDocuments: vi.fn().mockResolvedValue({
+        documents: [
+          { slug: 'doc1', title: 'Doc 1', draft: false },
+          { slug: 'doc2', title: 'Doc 2', draft: false },
+        ],
+        error: null,
+      }),
+    })) as any;
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+      loadCacheFn: mockLoadCache,
+      saveCacheFn: mockSaveCache,
+      createClientFn: mockCreateClient,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['doc1', 'doc2']);
+    expect(mockSaveCache).toHaveBeenCalledWith('workspace-1', ['doc1', 'doc2']);
+  });
+
+  it('uses cached slugs when available', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs',
+      prev: 'docs',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    const mockLoadCache = vi.fn(() => ['cached-doc1', 'cached-doc2']);
+    const mockSaveCache = vi.fn();
+    const mockCreateClient = vi.fn();
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+      loadCacheFn: mockLoadCache,
+      saveCacheFn: mockSaveCache,
+      createClientFn: mockCreateClient,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([
+      'cached-doc1',
+      'cached-doc2',
+    ]);
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('uses specified workspace for docs completion', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs -w workspace-2',
+      prev: '',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    const mockLoadCache = vi.fn(() => null);
+    const mockSaveCache = vi.fn().mockResolvedValue(undefined);
+    const mockCreateClient = vi.fn(() => ({
+      getDocuments: vi.fn().mockResolvedValue({
+        documents: [{ slug: 'doc3', title: 'Doc 3', draft: false }],
+        error: null,
+      }),
+    })) as any;
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+      loadCacheFn: mockLoadCache,
+      saveCacheFn: mockSaveCache,
+      createClientFn: mockCreateClient,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['doc3']);
+    expect(mockSaveCache).toHaveBeenCalledWith('workspace-2', ['doc3']);
+  });
+
+  it('returns empty array when API call fails', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs',
+      prev: 'docs',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    const mockLoadCache = vi.fn(() => null);
+    const mockSaveCache = vi.fn();
+    const mockCreateClient = vi.fn(() => ({
+      getDocuments: vi.fn().mockResolvedValue({
+        documents: null,
+        error: 'API Error',
+      }),
+    })) as any;
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+      loadCacheFn: mockLoadCache,
+      saveCacheFn: mockSaveCache,
+      createClientFn: mockCreateClient,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([]);
+  });
+
+  it('suggests default commands when no specific completion matches', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli',
+      prev: 'hscli',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        'docs',
+        'new',
+        'setup',
+        'config',
+        'completion',
+        'cache',
+      ]),
+    );
+  });
+
+  it('handles missing workspace gracefully', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs -w nonexistent',
+      prev: '',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).not.toHaveBeenCalled();
+  });
+
+  it('silently fails when config loading fails', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs',
+      prev: 'docs',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    const mockLoadConfig = vi.fn(() => {
+      throw new Error('Config load failed');
+    });
+
+    await expect(
+      completionHandler({
+        loadConfigFn: mockLoadConfig,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('calls default completion when workspace cannot be resolved for docs', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs',
+      prev: 'docs',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    const emptyConfig: Config = {
+      workspaces: {},
+      defaultWorkspace: undefined,
+      newFilenameTemplate: 'template',
+      docsDirs: [],
+    };
+
+    await completionHandler({
+      loadConfigFn: () => emptyConfig,
+    });
+
+    // When workspace cannot be resolved, completionHandler returns without logging
+    expect(vi.mocked(tabtab.log)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/__tests__/completion-handler.unit.test.ts
+++ b/packages/cli/src/__tests__/completion-handler.unit.test.ts
@@ -247,6 +247,53 @@ describe('completionHandler', () => {
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['show', 'list']);
   });
 
+  it('suggests config subcommands when prev is config', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli config',
+      prev: 'config',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
+      expect.arrayContaining(['init', 'list', 'get', 'set', 'delete', 'path'])
+    );
+  });
+
+  it('suggests completion subcommands when prev is completion', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli completion',
+      prev: 'completion',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['install']);
+  });
+
+  it('suggests cache subcommands when prev is cache', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli cache',
+      prev: 'cache',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['clear']);
+  });
+
   it('suggests default commands when no specific completion matches', async () => {
     const mockParseEnv = vi.fn(() => ({
       complete: true,
@@ -260,7 +307,7 @@ describe('completionHandler', () => {
     });
 
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
-      expect.arrayContaining(['docs', 'new', 'setup', 'config', 'completion', 'cache'])
+      expect.arrayContaining(['docs', 'new', 'setup', 'init', 'config', 'completion', 'cache'])
     );
   });
 
@@ -278,7 +325,7 @@ describe('completionHandler', () => {
 
     // Falls back to default command completion when workspace is missing
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
-      expect.arrayContaining(['docs', 'setup', 'config', 'completion', 'cache'])
+      expect.arrayContaining(['docs', 'setup', 'init', 'config', 'completion', 'cache'])
     );
   });
 

--- a/packages/cli/src/__tests__/completion-handler.unit.test.ts
+++ b/packages/cli/src/__tests__/completion-handler.unit.test.ts
@@ -1,10 +1,9 @@
 import tabtab from '@pnpm/tabtab';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { completionHandler } from '../completion-handler';
+import { completionHandler, type CompletionHandlerDeps } from '../completion-handler';
 
 import type { Config } from '../utils/load-config';
-
 
 // Mock tabtab module
 vi.mock('@pnpm/tabtab', () => ({
@@ -13,6 +12,16 @@ vi.mock('@pnpm/tabtab', () => ({
     log: vi.fn(),
   },
 }));
+
+// Test helper type for mocking client (minimal interface for testing)
+type MockClient = {
+  getDocuments: (args?: unknown) => Promise<{
+    documents: Array<{ slug: string; title: string; draft: boolean }> | null;
+    error: null | string;
+    totalCount?: number;
+    isEmpty?: boolean;
+  }>;
+};
 
 describe('completionHandler', () => {
   beforeEach(() => {
@@ -60,10 +69,7 @@ describe('completionHandler', () => {
       loadConfigFn: () => mockConfig,
     });
 
-    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([
-      'workspace-1',
-      'workspace-2',
-    ]);
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['workspace-1', 'workspace-2']);
   });
 
   it('suggests workspace slugs for -w option', async () => {
@@ -78,10 +84,7 @@ describe('completionHandler', () => {
       loadConfigFn: () => mockConfig,
     });
 
-    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([
-      'workspace-1',
-      'workspace-2',
-    ]);
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['workspace-1', 'workspace-2']);
   });
 
   it('suggests document slugs for docs command', async () => {
@@ -94,7 +97,8 @@ describe('completionHandler', () => {
 
     const mockLoadCache = vi.fn(() => null);
     const mockSaveCache = vi.fn().mockResolvedValue(undefined);
-    const mockCreateClient = vi.fn(() => ({
+
+    const mockClient: MockClient = {
       getDocuments: vi.fn().mockResolvedValue({
         documents: [
           { slug: 'doc1', title: 'Doc 1', draft: false },
@@ -102,12 +106,15 @@ describe('completionHandler', () => {
         ],
         error: null,
       }),
-    })) as any;
+    };
+
+    const mockCreateClient = vi.fn(() => mockClient);
 
     await completionHandler({
       loadConfigFn: () => mockConfig,
       loadCacheFn: mockLoadCache,
       saveCacheFn: mockSaveCache,
+      // @ts-expect-error - Mock Client differs from real Client in tests
       createClientFn: mockCreateClient,
     });
 
@@ -134,10 +141,7 @@ describe('completionHandler', () => {
       createClientFn: mockCreateClient,
     });
 
-    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([
-      'cached-doc1',
-      'cached-doc2',
-    ]);
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['cached-doc1', 'cached-doc2']);
     expect(mockCreateClient).not.toHaveBeenCalled();
   });
 
@@ -151,19 +155,22 @@ describe('completionHandler', () => {
 
     const mockLoadCache = vi.fn(() => null);
     const mockSaveCache = vi.fn().mockResolvedValue(undefined);
-    const mockCreateClient = vi.fn(() => ({
+
+    const mockClient: MockClient = {
       getDocuments: vi.fn().mockResolvedValue({
         documents: [{ slug: 'doc3', title: 'Doc 3', draft: false }],
         error: null,
       }),
-    })) as any;
+    };
+
+    const mockCreateClient = vi.fn(() => mockClient);
 
     await completionHandler({
       loadConfigFn: () => mockConfig,
       loadCacheFn: mockLoadCache,
       saveCacheFn: mockSaveCache,
       createClientFn: mockCreateClient,
-    });
+    } as unknown as Partial<CompletionHandlerDeps>);
 
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['doc3']);
     expect(mockSaveCache).toHaveBeenCalledWith('workspace-2', ['doc3']);
@@ -179,19 +186,22 @@ describe('completionHandler', () => {
 
     const mockLoadCache = vi.fn(() => null);
     const mockSaveCache = vi.fn();
-    const mockCreateClient = vi.fn(() => ({
+
+    const mockClient: MockClient = {
       getDocuments: vi.fn().mockResolvedValue({
         documents: null,
         error: 'API Error',
       }),
-    })) as any;
+    };
+
+    const mockCreateClient = vi.fn(() => mockClient);
 
     await completionHandler({
       loadConfigFn: () => mockConfig,
       loadCacheFn: mockLoadCache,
       saveCacheFn: mockSaveCache,
       createClientFn: mockCreateClient,
-    });
+    } as unknown as Partial<CompletionHandlerDeps>);
 
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([]);
   });
@@ -209,14 +219,7 @@ describe('completionHandler', () => {
     });
 
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        'docs',
-        'new',
-        'setup',
-        'config',
-        'completion',
-        'cache',
-      ]),
+      expect.arrayContaining(['docs', 'new', 'setup', 'config', 'completion', 'cache'])
     );
   });
 
@@ -232,7 +235,10 @@ describe('completionHandler', () => {
       loadConfigFn: () => mockConfig,
     });
 
-    expect(vi.mocked(tabtab.log)).not.toHaveBeenCalled();
+    // Falls back to default command completion when workspace is missing
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
+      expect.arrayContaining(['docs', 'setup', 'config', 'completion', 'cache'])
+    );
   });
 
   it('silently fails when config loading fails', async () => {
@@ -250,7 +256,7 @@ describe('completionHandler', () => {
     await expect(
       completionHandler({
         loadConfigFn: mockLoadConfig,
-      }),
+      })
     ).resolves.toBeUndefined();
   });
 
@@ -273,7 +279,9 @@ describe('completionHandler', () => {
       loadConfigFn: () => emptyConfig,
     });
 
-    // When workspace cannot be resolved, completionHandler returns without logging
-    expect(vi.mocked(tabtab.log)).not.toHaveBeenCalled();
+    // When workspace cannot be resolved, completionHandler provides default command completion
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
+      expect.arrayContaining(['docs', 'setup', 'config', 'completion', 'cache'])
+    );
   });
 });

--- a/packages/cli/src/__tests__/completion-handler.unit.test.ts
+++ b/packages/cli/src/__tests__/completion-handler.unit.test.ts
@@ -232,6 +232,21 @@ describe('completionHandler', () => {
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([]);
   });
 
+  it('suggests docs subcommands when prev is docs', async () => {
+    const mockParseEnv = vi.fn(() => ({
+      complete: true,
+      line: 'hscli docs',
+      prev: 'docs',
+    }));
+    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
+
+    await completionHandler({
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['show', 'list']);
+  });
+
   it('suggests default commands when no specific completion matches', async () => {
     const mockParseEnv = vi.fn(() => ({
       complete: true,
@@ -284,30 +299,5 @@ describe('completionHandler', () => {
         loadConfigFn: mockLoadConfig,
       })
     ).resolves.toBeUndefined();
-  });
-
-  it('calls default completion when workspace cannot be resolved for docs', async () => {
-    const mockParseEnv = vi.fn(() => ({
-      complete: true,
-      line: 'hscli docs',
-      prev: 'docs',
-    }));
-    vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
-
-    const emptyConfig: Config = {
-      workspaces: {},
-      defaultWorkspace: undefined,
-      newFilenameTemplate: 'template',
-      docsDirs: [],
-    };
-
-    await completionHandler({
-      loadConfigFn: () => emptyConfig,
-    });
-
-    // When workspace cannot be resolved, completionHandler provides default command completion
-    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
-      expect.arrayContaining(['docs', 'setup', 'config', 'completion', 'cache'])
-    );
   });
 });

--- a/packages/cli/src/__tests__/completion-handler.unit.test.ts
+++ b/packages/cli/src/__tests__/completion-handler.unit.test.ts
@@ -17,7 +17,7 @@ vi.mock('@pnpm/tabtab', () => ({
 // Test helper type for mocking client (minimal interface for testing)
 type MockClient = {
   getDocuments: (args?: unknown) => Promise<{
-    documents: Array<{ slug: string; title: string; draft: boolean }> | null;
+    documents: Array<{ slug: string; title: string; draft: boolean; id: string }> | null;
     error: null | string;
     totalCount?: number;
     isEmpty?: boolean;
@@ -107,8 +107,8 @@ describe('completionHandler', () => {
     const mockClient: MockClient = {
       getDocuments: vi.fn().mockResolvedValue({
         documents: [
-          { slug: 'doc1', title: 'Doc 1', draft: false },
-          { slug: 'doc2', title: 'Doc 2', draft: false },
+          { slug: 'doc1', title: 'Doc 1', draft: false, id: 'doc1-id' },
+          { slug: 'doc2', title: 'Doc 2', draft: false, id: 'doc2-id' },
         ],
         error: null,
       }),
@@ -181,7 +181,7 @@ describe('completionHandler', () => {
 
     const mockClient: MockClient = {
       getDocuments: vi.fn().mockResolvedValue({
-        documents: [{ slug: 'doc3', title: 'Doc 3', draft: false }],
+        documents: [{ slug: 'doc3', title: 'Doc 3', draft: false, id: 'doc3-id' }],
         error: null,
       }),
     };
@@ -228,6 +228,7 @@ describe('completionHandler', () => {
       createClientFn: mockCreateClient,
     } as unknown as Partial<CompletionHandlerDeps>);
 
+    // When API fails, returns empty array for completion items
     expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith([]);
   });
 

--- a/packages/cli/src/__tests__/completion-handler.unit.test.ts
+++ b/packages/cli/src/__tests__/completion-handler.unit.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { completionHandler, type CompletionHandlerDeps } from '../completion-handler';
 
+import type { DocumentCacheItem } from '../utils/cache';
 import type { Config } from '../utils/load-config';
 
 // Mock tabtab module
@@ -98,6 +99,11 @@ describe('completionHandler', () => {
     const mockLoadCache = vi.fn(() => null);
     const mockSaveCache = vi.fn().mockResolvedValue(undefined);
 
+    const mockDocuments: DocumentCacheItem[] = [
+      { slug: 'doc1', title: 'Doc 1' },
+      { slug: 'doc2', title: 'Doc 2' },
+    ];
+
     const mockClient: MockClient = {
       getDocuments: vi.fn().mockResolvedValue({
         documents: [
@@ -118,11 +124,16 @@ describe('completionHandler', () => {
       createClientFn: mockCreateClient,
     });
 
-    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['doc1', 'doc2']);
-    expect(mockSaveCache).toHaveBeenCalledWith('workspace-1', ['doc1', 'doc2']);
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        { name: 'doc1', description: 'Doc 1' },
+        { name: 'doc2', description: 'Doc 2' },
+      ])
+    );
+    expect(mockSaveCache).toHaveBeenCalledWith('workspace-1', mockDocuments);
   });
 
-  it('uses cached slugs when available', async () => {
+  it('uses cached documents when available', async () => {
     const mockParseEnv = vi.fn(() => ({
       complete: true,
       line: 'hscli docs',
@@ -130,7 +141,12 @@ describe('completionHandler', () => {
     }));
     vi.mocked(tabtab.parseEnv).mockImplementation(mockParseEnv);
 
-    const mockLoadCache = vi.fn(() => ['cached-doc1', 'cached-doc2']);
+    const cachedDocuments: DocumentCacheItem[] = [
+      { slug: 'cached-doc1', title: 'Cached Doc 1' },
+      { slug: 'cached-doc2', title: 'Cached Doc 2' },
+    ];
+
+    const mockLoadCache = vi.fn(() => cachedDocuments);
     const mockSaveCache = vi.fn();
     const mockCreateClient = vi.fn();
 
@@ -141,7 +157,12 @@ describe('completionHandler', () => {
       createClientFn: mockCreateClient,
     });
 
-    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['cached-doc1', 'cached-doc2']);
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        { name: 'cached-doc1', description: 'Cached Doc 1' },
+        { name: 'cached-doc2', description: 'Cached Doc 2' },
+      ])
+    );
     expect(mockCreateClient).not.toHaveBeenCalled();
   });
 
@@ -155,6 +176,8 @@ describe('completionHandler', () => {
 
     const mockLoadCache = vi.fn(() => null);
     const mockSaveCache = vi.fn().mockResolvedValue(undefined);
+
+    const mockDocuments: DocumentCacheItem[] = [{ slug: 'doc3', title: 'Doc 3' }];
 
     const mockClient: MockClient = {
       getDocuments: vi.fn().mockResolvedValue({
@@ -172,8 +195,10 @@ describe('completionHandler', () => {
       createClientFn: mockCreateClient,
     } as unknown as Partial<CompletionHandlerDeps>);
 
-    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(['doc3']);
-    expect(mockSaveCache).toHaveBeenCalledWith('workspace-2', ['doc3']);
+    expect(vi.mocked(tabtab.log)).toHaveBeenCalledWith(
+      expect.arrayContaining([{ name: 'doc3', description: 'Doc 3' }])
+    );
+    expect(mockSaveCache).toHaveBeenCalledWith('workspace-2', mockDocuments);
   });
 
   it('returns empty array when API call fails', async () => {

--- a/packages/cli/src/actions/__tests__/docs-show-action.unit.test.ts
+++ b/packages/cli/src/actions/__tests__/docs-show-action.unit.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { docsShowAction } from '../docs-show-action';
+
+import type { Config } from '../../utils/load-config';
+
+describe('docsShowAction', () => {
+  const mockConfig: Config = {
+    workspaces: {
+      'workspace-1': {
+        accessKey: 'test-key-1',
+      },
+    },
+    defaultWorkspace: 'workspace-1',
+    newFilenameTemplate: 'template',
+    docsDirs: ['docs'],
+  };
+
+  const mockDocument = {
+    id: 'doc-123',
+    slug: 'test-doc',
+    title: 'Test Document',
+    content: 'This is test content',
+    draft: false,
+  };
+
+  const createMockClient = (document = mockDocument) => ({
+    getDocument: vi.fn().mockResolvedValue({
+      document,
+      error: null,
+    }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows error when slug is not provided', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+
+    await docsShowAction('', {}, { logger: mockLogger, exitHandler: mockExitHandler });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Missing required argument'));
+    expect(mockExitHandler.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('shows error when config loading fails', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadConfig = vi.fn().mockImplementation(() => {
+      throw new Error('Config error');
+    });
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: mockLoadConfig,
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to load configuration'));
+    expect(mockExitHandler.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('shows error when no workspaces configured', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadConfig = vi.fn().mockReturnValue({ workspaces: {}, docsDirs: [] });
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: mockLoadConfig,
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('No workspaces configured'));
+    expect(mockExitHandler.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('shows error when specified workspace is not configured', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+
+    await docsShowAction('test-doc', { workspace: 'nonexistent' }, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('is not configured'));
+    expect(mockExitHandler.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('shows error when API connection fails', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockCreateClient = vi.fn(() => ({
+      getDocument: vi.fn().mockRejectedValue(new Error('Network error')),
+    }));
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to connect to the API'));
+    expect(mockExitHandler.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('shows error when API returns error', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockCreateClient = vi.fn(() => ({
+      getDocument: vi.fn().mockResolvedValue({
+        document: null,
+        error: 'API Error',
+      }),
+    }));
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('API returned an error'));
+    expect(mockExitHandler.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('shows error when document is not found', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockCreateClient = vi.fn(() => ({
+      getDocument: vi.fn().mockResolvedValue({
+        document: null,
+        error: null,
+      }),
+    }));
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+    });
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Document not found'));
+    expect(mockExitHandler.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('loads document from cache when available', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(mockDocument);
+    const mockCreateClient = vi.fn();
+    const mockSaveDocumentCache = vi.fn();
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+      saveDocumentCacheFn: mockSaveDocumentCache,
+    });
+
+    expect(mockLoadDocumentCache).toHaveBeenCalledWith('workspace-1', 'test-doc');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+    expect(mockLogger.log).toHaveBeenCalledWith(mockDocument.content);
+  });
+
+  it('fetches from API when cache is empty and saves to cache', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+    const mockCreateClient = vi.fn(() => createMockClient());
+    const mockSaveDocumentCache = vi.fn().mockResolvedValue(undefined);
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+      saveDocumentCacheFn: mockSaveDocumentCache,
+    });
+
+    expect(mockLoadDocumentCache).toHaveBeenCalledWith('workspace-1', 'test-doc');
+    expect(mockCreateClient).toHaveBeenCalled();
+    expect(mockSaveDocumentCache).toHaveBeenCalledWith('workspace-1', 'test-doc', expect.objectContaining(mockDocument));
+    expect(mockLogger.log).toHaveBeenCalledWith(mockDocument.content);
+  });
+
+  it('bypasses cache when --refresh flag is provided', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(mockDocument);
+    const mockCreateClient = vi.fn(() => createMockClient());
+    const mockSaveDocumentCache = vi.fn().mockResolvedValue(undefined);
+
+    await docsShowAction('test-doc', { refresh: true }, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+      saveDocumentCacheFn: mockSaveDocumentCache,
+    });
+
+    expect(mockLoadDocumentCache).not.toHaveBeenCalled();
+    expect(mockCreateClient).toHaveBeenCalled();
+    expect(mockSaveDocumentCache).toHaveBeenCalled();
+    expect(mockLogger.log).toHaveBeenCalledWith(mockDocument.content);
+  });
+
+  it('creates client with correct URL and access key', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+    const mockCreateClient = vi.fn(() => createMockClient());
+    const mockSaveDocumentCache = vi.fn().mockResolvedValue(undefined);
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+      saveDocumentCacheFn: mockSaveDocumentCache,
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      url: 'https://api.hackersheet.com/workspace-1/v1/graphql',
+      accessKey: 'test-key-1',
+    });
+  });
+
+  it('uses workspace from --workspace option', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+    const mockCreateClient = vi.fn(() => createMockClient());
+    const mockSaveDocumentCache = vi.fn().mockResolvedValue(undefined);
+    const multiWorkspaceConfig: Config = {
+      ...mockConfig,
+      workspaces: {
+        'workspace-1': { accessKey: 'key-1' },
+        'workspace-2': { accessKey: 'key-2' },
+      },
+    };
+
+    await docsShowAction('test-doc', { workspace: 'workspace-2' }, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => multiWorkspaceConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+      saveDocumentCacheFn: mockSaveDocumentCache,
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      url: 'https://api.hackersheet.com/workspace-2/v1/graphql',
+      accessKey: 'key-2',
+    });
+  });
+
+  it('uses defaultWorkspace when no --workspace option', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+    const mockCreateClient = vi.fn(() => createMockClient());
+    const mockSaveDocumentCache = vi.fn().mockResolvedValue(undefined);
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => mockConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+      saveDocumentCacheFn: mockSaveDocumentCache,
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      url: 'https://api.hackersheet.com/workspace-1/v1/graphql',
+      accessKey: 'test-key-1',
+    });
+  });
+
+  it('auto-selects single workspace when no default set', async () => {
+    const mockLogger = { log: vi.fn(), error: vi.fn() };
+    const mockExitHandler = { exit: vi.fn() };
+    const mockLoadDocumentCache = vi.fn().mockReturnValue(null);
+    const mockCreateClient = vi.fn(() => createMockClient());
+    const mockSaveDocumentCache = vi.fn().mockResolvedValue(undefined);
+    const singleWorkspaceConfig: Config = {
+      ...mockConfig,
+      defaultWorkspace: undefined,
+    };
+
+    await docsShowAction('test-doc', {}, {
+      logger: mockLogger,
+      exitHandler: mockExitHandler,
+      loadConfigFn: () => singleWorkspaceConfig,
+      // @ts-expect-error - Mock client for testing
+      createClientFn: mockCreateClient,
+      loadDocumentCacheFn: mockLoadDocumentCache,
+      saveDocumentCacheFn: mockSaveDocumentCache,
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      url: 'https://api.hackersheet.com/workspace-1/v1/graphql',
+      accessKey: 'test-key-1',
+    });
+  });
+});

--- a/packages/cli/src/actions/__tests__/init-action.unit.test.ts
+++ b/packages/cli/src/actions/__tests__/init-action.unit.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { initAction, type InitActionDeps } from '../init-action';
+
+// Mock loadUserConfig to always return setup completed
+vi.mock('../../utils/load-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/load-config')>();
+  return {
+    ...actual,
+    loadUserConfig: vi.fn().mockReturnValue({
+      workspaces: { 'test-workspace': { accessKey: 'test-key' } },
+    }),
+  };
+});
+
+describe('initAction', () => {
+  const createMockDeps = (overrides: Partial<InitActionDeps> = {}): InitActionDeps => ({
+    fsApi: {
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      access: vi.fn().mockRejectedValue(new Error('ENOENT')),
+    },
+    prompts: {
+      input: vi.fn().mockImplementation(({ message }) => {
+        if (message.includes('template')) return Promise.resolve('{{yyyy}}-{{mm}}-{{dd}}-{{title}}.md');
+        if (message.includes('directories')) return Promise.resolve('docs, guides');
+        return Promise.resolve('');
+      }),
+      confirm: vi.fn().mockResolvedValue(true),
+    },
+    logger: { log: vi.fn(), error: vi.fn() },
+    cwd: vi.fn().mockReturnValue('/project'),
+    configInitDeps: {
+      loadConfigFromPath: vi.fn().mockReturnValue(null),
+    },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates .hackersheet directory and trees subdirectory', async () => {
+    const deps = createMockDeps();
+
+    await initAction(deps);
+
+    expect(deps.fsApi.mkdir).toHaveBeenCalledWith('/project/.hackersheet', { recursive: true });
+    expect(deps.fsApi.mkdir).toHaveBeenCalledWith('/project/.hackersheet/trees', { recursive: true });
+  });
+
+  it('writes configuration file with project settings', async () => {
+    const deps = createMockDeps();
+
+    await initAction(deps);
+
+    const writeCall = vi.mocked(deps.fsApi.writeFile).mock.calls[0];
+    const config = JSON.parse(writeCall[1] as string);
+
+    expect(config.newFilenameTemplate).toBe('{{yyyy}}-{{mm}}-{{dd}}-{{title}}.md');
+    expect(config.docsDirs).toEqual(['docs', 'guides']);
+  });
+
+  it('does not write workspace configuration in init', async () => {
+    const deps = createMockDeps();
+
+    await initAction(deps);
+
+    const writeCall = vi.mocked(deps.fsApi.writeFile).mock.calls[0];
+    const config = JSON.parse(writeCall[1] as string);
+
+    expect(config.workspaces).toBeUndefined();
+    expect(config.defaultWorkspace).toBeUndefined();
+  });
+
+  it('logs success message', async () => {
+    const deps = createMockDeps();
+
+    await initAction(deps);
+
+    expect(deps.logger.log).toHaveBeenCalledWith(expect.stringContaining('Project initialization completed'));
+    expect(deps.logger.log).toHaveBeenCalledWith(expect.stringContaining('.hackersheet'));
+  });
+
+  it('prompts for overwrite when config already exists', async () => {
+    const deps = createMockDeps({
+      fsApi: {
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        access: vi.fn().mockResolvedValue(undefined), // file exists
+      },
+    });
+
+    await initAction(deps);
+
+    expect(deps.prompts.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('already initialized'),
+      })
+    );
+  });
+
+  it('cancels initialization when user declines overwrite', async () => {
+    const deps = createMockDeps({
+      fsApi: {
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        access: vi.fn().mockResolvedValue(undefined),
+      },
+      prompts: {
+        input: vi.fn(),
+        confirm: vi.fn().mockResolvedValue(false),
+      },
+    });
+
+    await initAction(deps);
+
+    expect(deps.logger.log).toHaveBeenCalledWith(expect.stringContaining('Initialization cancelled'));
+    expect(deps.fsApi.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('handles empty docsDirs input with default', async () => {
+    const deps = createMockDeps({
+      prompts: {
+        input: vi.fn().mockImplementation(({ message }) => {
+          if (message.includes('directories')) return Promise.resolve('');
+          return Promise.resolve('');
+        }),
+        confirm: vi.fn().mockResolvedValue(true),
+      },
+    });
+
+    await initAction(deps);
+
+    const writeCall = vi.mocked(deps.fsApi.writeFile).mock.calls[0];
+    const config = JSON.parse(writeCall[1] as string);
+
+    expect(config.docsDirs).toEqual(['docs']);
+  });
+
+  it('prompts for project configuration fields only', async () => {
+    const deps = createMockDeps();
+
+    await initAction(deps);
+
+    // Should prompt for project fields
+    expect(deps.prompts.input).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('filename template') })
+    );
+    expect(deps.prompts.input).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Document directories') })
+    );
+
+    // Should NOT prompt for workspace fields
+    const inputCalls = vi.mocked(deps.prompts.input).mock.calls;
+    const allMessages = inputCalls.map((call) => (call[0] as { message: string }).message);
+    expect(allMessages.some((msg) => msg.includes('Workspace slug'))).toBe(false);
+    expect(allMessages.some((msg) => msg.includes('access key'))).toBe(false);
+  });
+
+  it('logs initialization header message', async () => {
+    const deps = createMockDeps();
+
+    await initAction(deps);
+
+    expect(deps.logger.log).toHaveBeenCalledWith(expect.stringContaining('Hacker Sheet Project Initialization'));
+  });
+});

--- a/packages/cli/src/actions/__tests__/new-action.unit.test.ts
+++ b/packages/cli/src/actions/__tests__/new-action.unit.test.ts
@@ -138,7 +138,7 @@ describe('newAction', () => {
     );
   });
 
-  it('uses default directory when docsDirs is empty', async () => {
+  it('shows error when project is not initialized', async () => {
     const deps = createMockDeps({
       loadConfigFn: vi.fn().mockReturnValue({
         workspaces: {},
@@ -149,11 +149,9 @@ describe('newAction', () => {
 
     await newAction(deps);
 
-    expect(deps.prompts.select).toHaveBeenCalledWith(
-      expect.objectContaining({
-        choices: [{ name: 'docs', value: 'docs' }],
-      })
-    );
+    expect(deps.logger.error).toHaveBeenCalledWith(expect.stringContaining('Project not initialized'));
+    expect(deps.logger.error).toHaveBeenCalledWith(expect.stringContaining('hscli init'));
+    expect(deps.prompts.select).not.toHaveBeenCalled();
   });
 
   it('replaces spaces in title for filename', async () => {

--- a/packages/cli/src/actions/__tests__/setup-action.unit.test.ts
+++ b/packages/cli/src/actions/__tests__/setup-action.unit.test.ts
@@ -13,8 +13,6 @@ describe('setupAction', () => {
       input: vi.fn().mockImplementation(({ message }) => {
         if (message.includes('slug')) return Promise.resolve('my-workspace');
         if (message.includes('access key')) return Promise.resolve('secret-key');
-        if (message.includes('template')) return Promise.resolve('{{yyyy}}-{{title}}.md');
-        if (message.includes('directories')) return Promise.resolve('docs, guides');
         return Promise.resolve('');
       }),
       confirm: vi.fn().mockResolvedValue(true),
@@ -28,16 +26,17 @@ describe('setupAction', () => {
     vi.clearAllMocks();
   });
 
-  it('creates .hackersheet directory and trees subdirectory', async () => {
+  it('creates global config directory', async () => {
     const deps = createMockDeps();
 
     await setupAction(deps);
 
-    expect(deps.fsApi.mkdir).toHaveBeenCalledWith('/project/.hackersheet', { recursive: true });
-    expect(deps.fsApi.mkdir).toHaveBeenCalledWith('/project/.hackersheet/trees', { recursive: true });
+    expect(deps.fsApi.mkdir).toHaveBeenCalledWith(expect.stringContaining('.config/hackersheet'), {
+      recursive: true,
+    });
   });
 
-  it('writes configuration file with user input', async () => {
+  it('writes configuration file with workspace settings', async () => {
     const deps = createMockDeps();
 
     await setupAction(deps);
@@ -51,7 +50,7 @@ describe('setupAction', () => {
     expect(config.defaultWorkspace).toBe('my-workspace');
   });
 
-  it('parses comma-separated docsDirs', async () => {
+  it('does not write template or docsDirs in setup', async () => {
     const deps = createMockDeps();
 
     await setupAction(deps);
@@ -59,16 +58,27 @@ describe('setupAction', () => {
     const writeCall = vi.mocked(deps.fsApi.writeFile).mock.calls[0];
     const config = JSON.parse(writeCall[1] as string);
 
-    expect(config.docsDirs).toEqual(['docs', 'guides']);
+    expect(config.newFilenameTemplate).toBeUndefined();
+    expect(config.docsDirs).toBeUndefined();
   });
 
-  it('logs success message', async () => {
+  it('logs success message with global config path', async () => {
     const deps = createMockDeps();
 
     await setupAction(deps);
 
     expect(deps.logger.log).toHaveBeenCalledWith(expect.stringContaining('Setup completed'));
-    expect(deps.logger.log).toHaveBeenCalledWith(expect.stringContaining('/project/.hackersheet'));
+    expect(deps.logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('.config/hackersheet/cli.config.json')
+    );
+  });
+
+  it('suggests running hscli init next', async () => {
+    const deps = createMockDeps();
+
+    await setupAction(deps);
+
+    expect(deps.logger.log).toHaveBeenCalledWith(expect.stringContaining('hscli init'));
   });
 
   it('prompts for overwrite when config already exists', async () => {
@@ -84,7 +94,7 @@ describe('setupAction', () => {
 
     expect(deps.prompts.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining('already initialized'),
+        message: expect.stringContaining('already set up'),
       })
     );
   });
@@ -108,7 +118,7 @@ describe('setupAction', () => {
     expect(deps.fsApi.writeFile).not.toHaveBeenCalled();
   });
 
-  it('uses default template when user provides empty input', async () => {
+  it('handles empty workspace input', async () => {
     const deps = createMockDeps({
       prompts: {
         input: vi.fn().mockResolvedValue(''),
@@ -121,29 +131,8 @@ describe('setupAction', () => {
     const writeCall = vi.mocked(deps.fsApi.writeFile).mock.calls[0];
     const config = JSON.parse(writeCall[1] as string);
 
-    expect(config.newFilenameTemplate).toBe('{{yyyy}}-{{mm}}-{{dd}}-{{title}}.md');
-    expect(config.docsDirs).toEqual(['docs']);
     expect(config.workspaces).toEqual({});
     expect(config.defaultWorkspace).toBeUndefined();
-  });
-
-  it('handles empty docsDirs input', async () => {
-    const deps = createMockDeps({
-      prompts: {
-        input: vi.fn().mockImplementation(({ message }) => {
-          if (message.includes('directories')) return Promise.resolve('  ,  ,  ');
-          return Promise.resolve('');
-        }),
-        confirm: vi.fn().mockResolvedValue(true),
-      },
-    });
-
-    await setupAction(deps);
-
-    const writeCall = vi.mocked(deps.fsApi.writeFile).mock.calls[0];
-    const config = JSON.parse(writeCall[1] as string);
-
-    expect(config.docsDirs).toEqual(['docs']);
   });
 
   it('does not set workspace when only slug is provided', async () => {
@@ -152,8 +141,6 @@ describe('setupAction', () => {
         input: vi.fn().mockImplementation(({ message }) => {
           if (message.includes('slug')) return Promise.resolve('my-workspace');
           if (message.includes('access key')) return Promise.resolve('');
-          if (message.includes('template')) return Promise.resolve('');
-          if (message.includes('directories')) return Promise.resolve('docs');
           return Promise.resolve('');
         }),
         confirm: vi.fn().mockResolvedValue(true),
@@ -175,8 +162,6 @@ describe('setupAction', () => {
         input: vi.fn().mockImplementation(({ message }) => {
           if (message.includes('slug')) return Promise.resolve('');
           if (message.includes('access key')) return Promise.resolve('secret-key');
-          if (message.includes('template')) return Promise.resolve('');
-          if (message.includes('directories')) return Promise.resolve('docs');
           return Promise.resolve('');
         }),
         confirm: vi.fn().mockResolvedValue(true),
@@ -192,23 +177,24 @@ describe('setupAction', () => {
     expect(config.defaultWorkspace).toBeUndefined();
   });
 
-  it('prompts for all configuration fields', async () => {
+  it('prompts for workspace configuration fields only', async () => {
     const deps = createMockDeps();
 
     await setupAction(deps);
 
+    // Should prompt for workspace fields
     expect(deps.prompts.input).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('Workspace slug') })
     );
     expect(deps.prompts.input).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('access key') })
     );
-    expect(deps.prompts.input).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('filename template') })
-    );
-    expect(deps.prompts.input).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('directories') })
-    );
+
+    // Should NOT prompt for project fields
+    const inputCalls = vi.mocked(deps.prompts.input).mock.calls;
+    const allMessages = inputCalls.map((call) => (call[0] as { message: string }).message);
+    expect(allMessages.some((msg) => msg.includes('filename template'))).toBe(false);
+    expect(allMessages.some((msg) => msg.includes('Document directories'))).toBe(false);
   });
 
   it('logs setup header message', async () => {

--- a/packages/cli/src/actions/cache/__tests__/cache-clear-action.unit.test.ts
+++ b/packages/cli/src/actions/cache/__tests__/cache-clear-action.unit.test.ts
@@ -5,19 +5,22 @@ import { cacheClearAction } from '../cache-clear-action';
 import type { Logger } from '../../../types/logger';
 
 describe('cacheClearAction', () => {
-  it('clears cache and logs success message', async () => {
+  it('clears both slugs cache and documents cache', async () => {
     const mockLogger: Logger = {
       log: vi.fn(),
       error: vi.fn(),
     };
     const mockClearCache = vi.fn().mockResolvedValue(undefined);
+    const mockClearDocumentsCache = vi.fn().mockResolvedValue(undefined);
 
     await cacheClearAction({
       logger: mockLogger,
       clearCacheFunc: mockClearCache,
+      clearDocumentsCacheFunc: mockClearDocumentsCache,
     });
 
     expect(mockClearCache).toHaveBeenCalled();
+    expect(mockClearDocumentsCache).toHaveBeenCalled();
     expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('Cache cleared successfully'));
   });
 
@@ -27,13 +30,34 @@ describe('cacheClearAction', () => {
       error: vi.fn(),
     };
     const mockClearCache = vi.fn().mockRejectedValue(new Error('Clear failed'));
+    const mockClearDocumentsCache = vi.fn().mockResolvedValue(undefined);
 
     await expect(
       cacheClearAction({
         logger: mockLogger,
         clearCacheFunc: mockClearCache,
+        clearDocumentsCacheFunc: mockClearDocumentsCache,
       })
     ).rejects.toThrow('Clear failed');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to clear cache'));
+  });
+
+  it('logs error when documents cache clear fails', async () => {
+    const mockLogger: Logger = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+    const mockClearCache = vi.fn().mockResolvedValue(undefined);
+    const mockClearDocumentsCache = vi.fn().mockRejectedValue(new Error('Documents clear failed'));
+
+    await expect(
+      cacheClearAction({
+        logger: mockLogger,
+        clearCacheFunc: mockClearCache,
+        clearDocumentsCacheFunc: mockClearDocumentsCache,
+      })
+    ).rejects.toThrow('Documents clear failed');
 
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to clear cache'));
   });

--- a/packages/cli/src/actions/cache/__tests__/cache-clear-action.unit.test.ts
+++ b/packages/cli/src/actions/cache/__tests__/cache-clear-action.unit.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 
-import { cacheClearAction, type Logger } from '../cache-clear-action';
+import { cacheClearAction } from '../cache-clear-action';
+
+import type { Logger } from '../../../types/logger';
 
 describe('cacheClearAction', () => {
   it('clears cache and logs success message', async () => {
@@ -16,9 +18,7 @@ describe('cacheClearAction', () => {
     });
 
     expect(mockClearCache).toHaveBeenCalled();
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      expect.stringContaining('Cache cleared successfully'),
-    );
+    expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('Cache cleared successfully'));
   });
 
   it('logs error when cache clear fails', async () => {
@@ -32,11 +32,9 @@ describe('cacheClearAction', () => {
       cacheClearAction({
         logger: mockLogger,
         clearCacheFunc: mockClearCache,
-      }),
+      })
     ).rejects.toThrow('Clear failed');
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to clear cache'),
-    );
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to clear cache'));
   });
 });

--- a/packages/cli/src/actions/cache/__tests__/cache-clear-action.unit.test.ts
+++ b/packages/cli/src/actions/cache/__tests__/cache-clear-action.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { cacheClearAction, type Logger } from '../cache-clear-action';
+
+describe('cacheClearAction', () => {
+  it('clears cache and logs success message', async () => {
+    const mockLogger: Logger = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+    const mockClearCache = vi.fn().mockResolvedValue(undefined);
+
+    await cacheClearAction({
+      logger: mockLogger,
+      clearCacheFunc: mockClearCache,
+    });
+
+    expect(mockClearCache).toHaveBeenCalled();
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('Cache cleared successfully'),
+    );
+  });
+
+  it('logs error when cache clear fails', async () => {
+    const mockLogger: Logger = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+    const mockClearCache = vi.fn().mockRejectedValue(new Error('Clear failed'));
+
+    await expect(
+      cacheClearAction({
+        logger: mockLogger,
+        clearCacheFunc: mockClearCache,
+      }),
+    ).rejects.toThrow('Clear failed');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to clear cache'),
+    );
+  });
+});

--- a/packages/cli/src/actions/cache/cache-clear-action.ts
+++ b/packages/cli/src/actions/cache/cache-clear-action.ts
@@ -1,13 +1,7 @@
 import { clearCache } from '../../utils/cache';
 import { colors, symbols } from '../../utils/colors';
 
-/**
- * Logger interface for output, enabling dependency injection in tests.
- */
-export type Logger = {
-  log: (...args: unknown[]) => void;
-  error: (...args: unknown[]) => void;
-};
+import type { Logger } from '../../types/logger';
 
 /**
  * Dependencies for the cacheClearAction function.

--- a/packages/cli/src/actions/cache/cache-clear-action.ts
+++ b/packages/cli/src/actions/cache/cache-clear-action.ts
@@ -1,0 +1,43 @@
+import { clearCache } from '../../utils/cache';
+import { colors, symbols } from '../../utils/colors';
+
+/**
+ * Logger interface for output, enabling dependency injection in tests.
+ */
+export type Logger = {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+/**
+ * Dependencies for the cacheClearAction function.
+ */
+export type CacheClearActionDeps = {
+  logger: Logger;
+  clearCacheFunc: typeof clearCache;
+};
+
+const defaultDeps: CacheClearActionDeps = {
+  logger: { log: console.log, error: console.error },
+  clearCacheFunc: clearCache,
+};
+
+/**
+ * Clear the CLI cache.
+ *
+ * This is the action handler for the `cache clear` command.
+ * Deletes the cached slug data to force a fresh fetch from the API.
+ *
+ * @param deps - Optional dependencies for testing.
+ */
+export async function cacheClearAction(deps: Partial<CacheClearActionDeps> = {}): Promise<void> {
+  const { logger, clearCacheFunc } = { ...defaultDeps, ...deps };
+
+  try {
+    await clearCacheFunc();
+    logger.log(`${symbols.success()} ${colors.success('Cache cleared successfully!')}`);
+  } catch (error) {
+    logger.error(`${symbols.error()} ${colors.error('Failed to clear cache')}`);
+    throw error;
+  }
+}

--- a/packages/cli/src/actions/cache/cache-clear-action.ts
+++ b/packages/cli/src/actions/cache/cache-clear-action.ts
@@ -1,4 +1,4 @@
-import { clearCache } from '../../utils/cache';
+import { clearCache, clearDocumentsCache } from '../../utils/cache';
 import { colors, symbols } from '../../utils/colors';
 
 import type { Logger } from '../../types/logger';
@@ -9,26 +9,29 @@ import type { Logger } from '../../types/logger';
 export type CacheClearActionDeps = {
   logger: Logger;
   clearCacheFunc: typeof clearCache;
+  clearDocumentsCacheFunc: typeof clearDocumentsCache;
 };
 
 const defaultDeps: CacheClearActionDeps = {
   logger: { log: console.log, error: console.error },
   clearCacheFunc: clearCache,
+  clearDocumentsCacheFunc: clearDocumentsCache,
 };
 
 /**
  * Clear the CLI cache.
  *
  * This is the action handler for the `cache clear` command.
- * Deletes the cached slug data to force a fresh fetch from the API.
+ * Deletes the cached slug data and document content to force a fresh fetch from the API.
  *
  * @param deps - Optional dependencies for testing.
  */
 export async function cacheClearAction(deps: Partial<CacheClearActionDeps> = {}): Promise<void> {
-  const { logger, clearCacheFunc } = { ...defaultDeps, ...deps };
+  const { logger, clearCacheFunc, clearDocumentsCacheFunc } = { ...defaultDeps, ...deps };
 
   try {
     await clearCacheFunc();
+    await clearDocumentsCacheFunc();
     logger.log(`${symbols.success()} ${colors.success('Cache cleared successfully!')}`);
   } catch (error) {
     logger.error(`${symbols.error()} ${colors.error('Failed to clear cache')}`);

--- a/packages/cli/src/actions/completion/__tests__/completion-install-action.unit.test.ts
+++ b/packages/cli/src/actions/completion/__tests__/completion-install-action.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  completionInstallAction,
+  type Logger,
+} from '../completion-install-action';
+
+describe('completionInstallAction', () => {
+  it('installs completion and logs success message', async () => {
+    const mockLogger: Logger = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+    const mockTabtabInstall = vi.fn().mockResolvedValue(undefined);
+
+    await completionInstallAction({
+      logger: mockLogger,
+      tabtabInstall: mockTabtabInstall,
+    });
+
+    expect(mockTabtabInstall).toHaveBeenCalled();
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('Shell completion installed'),
+    );
+  });
+
+  it('logs restart instruction after installation', async () => {
+    const mockLogger: Logger = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+    const mockTabtabInstall = vi.fn().mockResolvedValue(undefined);
+
+    await completionInstallAction({
+      logger: mockLogger,
+      tabtabInstall: mockTabtabInstall,
+    });
+
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('Restart your shell'),
+    );
+  });
+
+  it('logs manual setup instructions when installation fails', async () => {
+    const mockLogger: Logger = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+    const mockTabtabInstall = vi.fn().mockRejectedValue(
+      new Error('Installation failed'),
+    );
+
+    await completionInstallAction({
+      logger: mockLogger,
+      tabtabInstall: mockTabtabInstall,
+    });
+
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Tabtab installation could not auto-setup completion',
+      ),
+    );
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('Manual setup'),
+    );
+  });
+});

--- a/packages/cli/src/actions/completion/__tests__/completion-install-action.unit.test.ts
+++ b/packages/cli/src/actions/completion/__tests__/completion-install-action.unit.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 
-import {
-  completionInstallAction,
-  type Logger,
-} from '../completion-install-action';
+import { completionInstallAction } from '../completion-install-action';
+
+import type { Logger } from '../../../types/logger';
 
 describe('completionInstallAction', () => {
   it('installs completion and logs success message', async () => {
@@ -19,9 +18,7 @@ describe('completionInstallAction', () => {
     });
 
     expect(mockTabtabInstall).toHaveBeenCalled();
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      expect.stringContaining('Shell completion installed'),
-    );
+    expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('Shell completion installed'));
   });
 
   it('logs restart instruction after installation', async () => {
@@ -36,9 +33,7 @@ describe('completionInstallAction', () => {
       tabtabInstall: mockTabtabInstall,
     });
 
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      expect.stringContaining('Restart your shell'),
-    );
+    expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('Restart your shell'));
   });
 
   it('logs manual setup instructions when installation fails', async () => {
@@ -46,9 +41,7 @@ describe('completionInstallAction', () => {
       log: vi.fn(),
       error: vi.fn(),
     };
-    const mockTabtabInstall = vi.fn().mockRejectedValue(
-      new Error('Installation failed'),
-    );
+    const mockTabtabInstall = vi.fn().mockRejectedValue(new Error('Installation failed'));
 
     await completionInstallAction({
       logger: mockLogger,
@@ -56,12 +49,8 @@ describe('completionInstallAction', () => {
     });
 
     expect(mockLogger.log).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Tabtab installation could not auto-setup completion',
-      ),
+      expect.stringContaining('Tabtab installation could not auto-setup completion')
     );
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      expect.stringContaining('Manual setup'),
-    );
+    expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('Manual setup'));
   });
 });

--- a/packages/cli/src/actions/completion/completion-install-action.ts
+++ b/packages/cli/src/actions/completion/completion-install-action.ts
@@ -2,13 +2,7 @@ import tabtab from '@pnpm/tabtab';
 
 import { colors, symbols } from '../../utils/colors';
 
-/**
- * Logger interface for output, enabling dependency injection in tests.
- */
-export type Logger = {
-  log: (...args: unknown[]) => void;
-  error: (...args: unknown[]) => void;
-};
+import type { Logger } from '../../types/logger';
 
 /**
  * Dependencies for the completionInstallAction function.

--- a/packages/cli/src/actions/completion/completion-install-action.ts
+++ b/packages/cli/src/actions/completion/completion-install-action.ts
@@ -1,0 +1,51 @@
+import tabtab from '@pnpm/tabtab';
+
+import { colors, symbols } from '../../utils/colors';
+
+/**
+ * Logger interface for output, enabling dependency injection in tests.
+ */
+export type Logger = {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+/**
+ * Dependencies for the completionInstallAction function.
+ */
+export type CompletionInstallActionDeps = {
+  logger: Logger;
+  tabtabInstall: () => Promise<void>;
+};
+
+const defaultDeps: CompletionInstallActionDeps = {
+  logger: { log: console.log, error: console.error },
+  tabtabInstall: () => tabtab.install({ name: 'hscli', completer: 'hscli' }),
+};
+
+/**
+ * Install shell completion.
+ *
+ * This is the action handler for the `completion install` command.
+ * Installs the shell completion script for the current shell.
+ *
+ * @param deps - Optional dependencies for testing.
+ */
+export async function completionInstallAction(deps: Partial<CompletionInstallActionDeps> = {}): Promise<void> {
+  const { logger, tabtabInstall } = { ...defaultDeps, ...deps };
+
+  try {
+    await tabtabInstall();
+
+    logger.log(`${symbols.success()} ${colors.success('Shell completion installed!')}`);
+    logger.log(`   ${colors.hint('Restart your shell or source your rc file to enable completion.')}`);
+  } catch {
+    // If tabtab fails, provide manual instruction
+    logger.log(`${symbols.info()} ${colors.hint('Tabtab installation could not auto-setup completion.')}`);
+    logger.log(`   ${colors.hint('Manual setup: Add the following to your ~/.zshrc or ~/.bashrc:')}`);
+    logger.log('');
+    logger.log(`   . <(hscli __completion)`);
+    logger.log('');
+    logger.log(`   ${colors.hint('Then restart your shell or run:')} source ~/.zshrc`);
+  }
+}

--- a/packages/cli/src/actions/config/__tests__/config-init-action.unit.test.ts
+++ b/packages/cli/src/actions/config/__tests__/config-init-action.unit.test.ts
@@ -30,7 +30,7 @@ describe('runConfigWizard', () => {
   it('returns configuration from user input', async () => {
     const deps = createMockDeps();
 
-    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', deps);
+    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps);
 
     expect(result.cancelled).toBe(false);
     expect(result.config.defaultWorkspace).toBe('my-workspace');
@@ -49,7 +49,7 @@ describe('runConfigWizard', () => {
       },
     });
 
-    await runConfigWizard('/project/.hackersheet/cli.config.json', deps);
+    await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps);
 
     expect(deps.prompts!.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -70,7 +70,7 @@ describe('runConfigWizard', () => {
       },
     });
 
-    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', deps);
+    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps);
 
     expect(result.cancelled).toBe(true);
     expect(deps.prompts!.input).not.toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe('runConfigWizard', () => {
       loadConfigFromPath: vi.fn().mockReturnValue(existingConfig),
     });
 
-    await runConfigWizard('/project/.hackersheet/cli.config.json', deps);
+    await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps);
 
     expect(deps.prompts!.input).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -105,7 +105,7 @@ describe('runConfigWizard', () => {
       },
     });
 
-    await runConfigWizard('/project/.hackersheet/cli.config.json', deps, {
+    await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps, {
       confirmMessage: 'Custom confirm message',
     });
 
@@ -119,7 +119,7 @@ describe('runConfigWizard', () => {
   it('uses custom header message when provided', async () => {
     const deps = createMockDeps();
 
-    await runConfigWizard('/project/.hackersheet/cli.config.json', deps, {
+    await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps, {
       headerMessage: 'Custom header',
     });
 
@@ -140,7 +140,7 @@ describe('runConfigWizard', () => {
       },
     });
 
-    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', deps);
+    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps);
 
     expect(result.config.workspaces).toEqual({});
     expect(result.config.defaultWorkspace).toBeUndefined();
@@ -154,7 +154,7 @@ describe('runConfigWizard', () => {
       },
     });
 
-    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', deps);
+    const result = await runConfigWizard('/project/.hackersheet/cli.config.json', 'all', deps);
 
     expect(result.config.newFilenameTemplate).toBe('{{yyyy}}-{{mm}}-{{dd}}-{{title}}.md');
     expect(result.config.docsDirs).toEqual(['docs']);

--- a/packages/cli/src/actions/config/__tests__/config-path-action.unit.test.ts
+++ b/packages/cli/src/actions/config/__tests__/config-path-action.unit.test.ts
@@ -7,6 +7,7 @@ describe('configPathAction', () => {
     logger: { log: vi.fn() },
     getUserConfigPath: vi.fn().mockReturnValue('/home/user/.config/hackersheet/cli.config.json'),
     getProjectConfigPath: vi.fn().mockReturnValue('/project/.hackersheet/cli.config.json'),
+    getCacheDir: vi.fn().mockReturnValue('/home/user/.cache/hackersheet'),
     ...overrides,
   });
 
@@ -14,13 +15,14 @@ describe('configPathAction', () => {
     vi.clearAllMocks();
   });
 
-  it('displays both paths by default', async () => {
+  it('displays all paths by default', async () => {
     const deps = createMockDeps();
 
     await configPathAction({}, deps);
 
     expect(deps.logger.log).toHaveBeenCalledWith('User:    /home/user/.config/hackersheet/cli.config.json');
     expect(deps.logger.log).toHaveBeenCalledWith('Project: /project/.hackersheet/cli.config.json');
+    expect(deps.logger.log).toHaveBeenCalledWith('Cache:   /home/user/.cache/hackersheet');
   });
 
   it('displays only user path with --global option', async () => {
@@ -59,5 +61,14 @@ describe('configPathAction', () => {
     await configPathAction({ local: true }, deps);
 
     expect(deps.logger.log).toHaveBeenCalledWith('(not found)');
+  });
+
+  it('displays only cache path with --cache option', async () => {
+    const deps = createMockDeps();
+
+    await configPathAction({ cache: true }, deps);
+
+    expect(deps.logger.log).toHaveBeenCalledTimes(1);
+    expect(deps.logger.log).toHaveBeenCalledWith('/home/user/.cache/hackersheet');
   });
 });

--- a/packages/cli/src/actions/config/config-init-action.ts
+++ b/packages/cli/src/actions/config/config-init-action.ts
@@ -31,6 +31,11 @@ export type Logger = {
 };
 
 /**
+ * Wizard mode: which fields to prompt for.
+ */
+export type ConfigWizardMode = 'global' | 'project' | 'all';
+
+/**
  * Options for the config init command.
  */
 export type ConfigInitOptions = {
@@ -110,12 +115,14 @@ export type ConfigInitResult = {
  * It can be used by both `config init` and `setup` commands.
  *
  * @param configPath - Path where the config will be saved.
+ * @param mode - Which fields to prompt for: 'global' (workspaces), 'project' (template/dirs), 'all'.
  * @param deps - Dependencies for testing.
  * @param options - Options for customizing wizard messages.
  * @returns The configuration result.
  */
 export async function runConfigWizard(
   configPath: string,
+  mode: ConfigWizardMode = 'all',
   deps: Partial<ConfigInitActionDeps> = {},
   options: ConfigWizardOptions = {}
 ): Promise<ConfigInitResult> {
@@ -139,31 +146,41 @@ export async function runConfigWizard(
 
   logger.log(headerMessage);
 
-  const workspaceSlug = await prompts.input({
-    message: 'Workspace slug (optional, for API access)',
-    default: existingConfig.defaultWorkspace ?? '',
-  });
+  // Global fields: workspace configuration
+  let workspaceSlug = '';
+  let accessKey = '';
+  if (mode === 'global' || mode === 'all') {
+    workspaceSlug = await prompts.input({
+      message: 'Workspace slug (optional, for API access)',
+      default: existingConfig.defaultWorkspace ?? '',
+    });
 
-  const existingAccessKey = workspaceSlug && existingConfig.workspaces?.[workspaceSlug]?.accessKey;
-  const accessKey = await prompts.input({
-    message: 'Workspace access key (optional, for API access)',
-    default: existingAccessKey ?? '',
-  });
+    const existingAccessKey = workspaceSlug && existingConfig.workspaces?.[workspaceSlug]?.accessKey;
+    accessKey = await prompts.input({
+      message: 'Workspace access key (optional, for API access)',
+      default: existingAccessKey ?? '',
+    });
+  }
 
-  const newFilenameTemplate = await prompts.input({
-    message: 'New document filename template',
-    default: existingConfig.newFilenameTemplate ?? DEFAULT_CONFIG.newFilenameTemplate,
-  });
+  // Project fields: template and directories
+  let newFilenameTemplate = '';
+  let docsDirs: string[] = [];
+  if (mode === 'project' || mode === 'all') {
+    newFilenameTemplate = await prompts.input({
+      message: 'New document filename template',
+      default: existingConfig.newFilenameTemplate ?? DEFAULT_CONFIG.newFilenameTemplate,
+    });
 
-  const docsDirsInput = await prompts.input({
-    message: 'Document directories (comma-separated)',
-    default: existingConfig.docsDirs?.join(', ') ?? 'docs',
-  });
+    const docsDirsInput = await prompts.input({
+      message: 'Document directories (comma-separated)',
+      default: existingConfig.docsDirs?.join(', ') ?? 'docs',
+    });
 
-  const docsDirs = docsDirsInput
-    .split(',')
-    .map((d) => d.trim())
-    .filter((d) => d.length > 0);
+    docsDirs = docsDirsInput
+      .split(',')
+      .map((d) => d.trim())
+      .filter((d) => d.length > 0);
+  }
 
   const workspaces: Config['workspaces'] = {};
   let defaultWorkspace: string | undefined;
@@ -173,12 +190,21 @@ export async function runConfigWizard(
     defaultWorkspace = workspaceSlug;
   }
 
-  const config: Partial<Config> = {
-    workspaces,
-    ...(defaultWorkspace && { defaultWorkspace }),
-    newFilenameTemplate: newFilenameTemplate || DEFAULT_CONFIG.newFilenameTemplate,
-    docsDirs: docsDirs.length > 0 ? docsDirs : DEFAULT_CONFIG.docsDirs,
-  };
+  const config: Partial<Config> = {};
+
+  // Add global fields if prompted
+  if (mode === 'global' || mode === 'all') {
+    config.workspaces = workspaces;
+    if (defaultWorkspace) {
+      config.defaultWorkspace = defaultWorkspace;
+    }
+  }
+
+  // Add project fields if prompted
+  if (mode === 'project' || mode === 'all') {
+    config.newFilenameTemplate = newFilenameTemplate || DEFAULT_CONFIG.newFilenameTemplate;
+    config.docsDirs = docsDirs.length > 0 ? docsDirs : DEFAULT_CONFIG.docsDirs;
+  }
 
   return { config, configPath, cancelled: false };
 }
@@ -207,10 +233,12 @@ export async function configInitAction(
 
   let configPath: string;
   let configType: string;
+  let mode: ConfigWizardMode;
 
   if (options.global) {
     configPath = getUserPath();
     configType = 'user';
+    mode = 'all'; // For `config init --global`, prompt all fields
   } else {
     const projectPath = getProjectPath();
     if (projectPath) {
@@ -219,9 +247,10 @@ export async function configInitAction(
       configPath = path.join(cwd(), '.hackersheet', 'cli.config.json');
     }
     configType = 'project';
+    mode = 'all'; // For `config init`, prompt all fields
   }
 
-  const result = await runConfigWizard(configPath, deps);
+  const result = await runConfigWizard(configPath, mode, deps);
 
   if (result.cancelled) {
     return;

--- a/packages/cli/src/actions/config/config-path-action.ts
+++ b/packages/cli/src/actions/config/config-path-action.ts
@@ -1,3 +1,4 @@
+import { getCacheDir } from '../../utils/cache';
 import { colors } from '../../utils/colors';
 import { getUserConfigPath, getProjectConfigPath } from '../../utils/load-config';
 
@@ -14,6 +15,7 @@ export type Logger = {
 export type ConfigPathOptions = {
   global?: boolean;
   local?: boolean;
+  cache?: boolean;
 };
 
 /**
@@ -23,19 +25,21 @@ export type ConfigPathActionDeps = {
   logger: Logger;
   getUserConfigPath: typeof getUserConfigPath;
   getProjectConfigPath: typeof getProjectConfigPath;
+  getCacheDir: typeof getCacheDir;
 };
 
 const defaultDeps: ConfigPathActionDeps = {
   logger: { log: console.log },
   getUserConfigPath,
   getProjectConfigPath,
+  getCacheDir,
 };
 
 /**
- * Displays configuration file paths.
+ * Displays configuration file and cache directory paths.
  *
  * This is the action handler for the `config path` command.
- * Shows the paths to user and/or project configuration files.
+ * Shows the paths to user and/or project configuration files, and cache directory.
  *
  * @param options - Command options.
  * @param deps - Optional dependencies for testing.
@@ -44,10 +48,24 @@ export async function configPathAction(
   options: ConfigPathOptions = {},
   deps: Partial<ConfigPathActionDeps> = {}
 ): Promise<void> {
-  const { logger, getUserConfigPath: getUserPath, getProjectConfigPath: getProjectPath } = { ...defaultDeps, ...deps };
+  const {
+    logger,
+    getUserConfigPath: getUserPath,
+    getProjectConfigPath: getProjectPath,
+    getCacheDir: getCacheDirFn,
+  } = {
+    ...defaultDeps,
+    ...deps,
+  };
 
   const userConfigPath = getUserPath();
   const projectConfigPath = getProjectPath();
+  const cacheDirPath = getCacheDirFn();
+
+  if (options.cache) {
+    logger.log(colors.path(cacheDirPath));
+    return;
+  }
 
   if (options.global) {
     logger.log(colors.path(userConfigPath));
@@ -59,9 +77,10 @@ export async function configPathAction(
     return;
   }
 
-  // Default: show both paths
+  // Default: show all paths
   logger.log(`${colors.info('User:')}    ${colors.path(userConfigPath)}`);
   logger.log(
     `${colors.info('Project:')} ${projectConfigPath ? colors.path(projectConfigPath) : colors.dim('(not found)')}`
   );
+  logger.log(`${colors.info('Cache:')}   ${colors.path(cacheDirPath)}`);
 }

--- a/packages/cli/src/actions/config/index.ts
+++ b/packages/cli/src/actions/config/index.ts
@@ -7,5 +7,6 @@ export {
   configInitAction,
   runConfigWizard,
   type ConfigInitActionDeps,
+  type ConfigWizardMode,
   type ConfigWizardOptions,
 } from './config-init-action';

--- a/packages/cli/src/actions/docs-list-action.ts
+++ b/packages/cli/src/actions/docs-list-action.ts
@@ -1,0 +1,257 @@
+import { createClient } from '@hackersheet/core';
+
+import { loadCache, saveCache, type DocumentCacheItem } from '../utils/cache';
+import { colors, symbols } from '../utils/colors';
+import { loadConfig, type Config, ConfigError } from '../utils/load-config';
+
+import type { Logger } from '../types/logger';
+
+/**
+ * Exit handler interface for process exit, enabling dependency injection in tests.
+ */
+export type ExitHandler = {
+  exit: (code?: number) => void;
+};
+
+/**
+ * Dependencies for the docsListAction function.
+ */
+export type DocsListActionDeps = {
+  logger: Logger;
+  exitHandler: ExitHandler;
+  loadConfigFn: () => Config;
+  createClientFn: typeof createClient;
+  loadCacheFn: (workspace: string) => DocumentCacheItem[] | null;
+  saveCacheFn: (workspace: string, documents: DocumentCacheItem[]) => Promise<void>;
+};
+
+const defaultDeps: DocsListActionDeps = {
+  logger: { log: console.log, error: console.error },
+  exitHandler: { exit: (code) => process.exit(code) },
+  loadConfigFn: loadConfig,
+  createClientFn: createClient,
+  loadCacheFn: loadCache,
+  saveCacheFn: saveCache,
+};
+
+/**
+ * Resolved workspace information.
+ */
+type ResolvedWorkspace = {
+  slug: string;
+  accessKey: string;
+};
+
+/**
+ * Resolves the workspace to use based on options and config.
+ *
+ * Resolution order:
+ * 1. --workspace option if specified
+ * 2. defaultWorkspace if configured
+ * 3. Single workspace if only one exists
+ * 4. null if none of the above
+ *
+ * @param config - The loaded configuration.
+ * @param workspaceOption - The workspace slug from CLI option.
+ * @returns The resolved workspace or null.
+ */
+function resolveWorkspace(config: Config, workspaceOption?: string): ResolvedWorkspace | null {
+  const workspaceSlugs = Object.keys(config.workspaces);
+
+  // 1. --workspace option specified
+  if (workspaceOption) {
+    const workspace = config.workspaces[workspaceOption];
+    if (!workspace) return null;
+    return { slug: workspaceOption, accessKey: workspace.accessKey };
+  }
+
+  // 2. defaultWorkspace configured
+  if (config.defaultWorkspace) {
+    const workspace = config.workspaces[config.defaultWorkspace];
+    if (!workspace) return null;
+    return { slug: config.defaultWorkspace, accessKey: workspace.accessKey };
+  }
+
+  // 3. Single workspace auto-select
+  if (workspaceSlugs.length === 1) {
+    const slug = workspaceSlugs[0];
+    const workspace = config.workspaces[slug];
+    return { slug, accessKey: workspace.accessKey };
+  }
+
+  // 4. Unable to resolve
+  return null;
+}
+
+/**
+ * Fetches all documents using cursor-based pagination with caching.
+ *
+ * @param workspace - The resolved workspace.
+ * @param deps - Partial dependencies for testing.
+ * @returns Array of documents with slug and title.
+ */
+async function fetchAllDocuments(
+  workspace: ResolvedWorkspace,
+  deps: Partial<DocsListActionDeps>
+): Promise<DocumentCacheItem[]> {
+  const { createClientFn, loadCacheFn, saveCacheFn } = {
+    ...defaultDeps,
+    ...deps,
+  };
+
+  // 1. Try to load from cache first
+  const cached = loadCacheFn(workspace.slug);
+  if (cached) {
+    return cached;
+  }
+
+  // 2. Fetch from API with cursor-based pagination to get all documents
+  try {
+    const url = `https://api.hackersheet.com/${workspace.slug}/v1/graphql`;
+    const client = createClientFn({
+      url,
+      accessKey: workspace.accessKey,
+    });
+
+    const allDocuments: DocumentCacheItem[] = [];
+    let after: string | undefined = undefined;
+    const pageSize = 100; // Fetch 100 documents per request
+
+    // Iterate through all pages
+    while (true) {
+      const { documents, error } = await client.getDocuments({
+        filter: { draft: false },
+        first: pageSize,
+        after,
+      });
+
+      if (error || !documents || documents.length === 0) {
+        break;
+      }
+
+      // Extract slug and title from each document
+      const batch: DocumentCacheItem[] = documents.map((doc) => ({
+        slug: doc.slug,
+        title: doc.title,
+      }));
+
+      allDocuments.push(...batch);
+
+      // If we got fewer documents than the page size, we've reached the end
+      if (documents.length < pageSize) {
+        break;
+      }
+
+      // Prepare for the next page: use the last document's ID as the cursor
+      const lastDoc = documents[documents.length - 1];
+      after = lastDoc.id;
+    }
+
+    // 3. Save to cache (fire and forget)
+    saveCacheFn(workspace.slug, allDocuments).catch(() => {
+      // Silently ignore cache errors
+    });
+
+    return allDocuments;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Options for the docs list action.
+ */
+export type DocsListActionOptions = {
+  /** Workspace slug to use (overrides default). */
+  workspace?: string;
+};
+
+/**
+ * Lists all available documents with their slugs and titles.
+ *
+ * This is the action handler for the `docs list` command.
+ * Displays a table of available documents with slug and title columns.
+ *
+ * @param options - Command options including workspace selection.
+ * @param deps - Optional dependencies for testing.
+ */
+export async function docsListAction(
+  options: DocsListActionOptions = {},
+  deps: Partial<DocsListActionDeps> = {}
+): Promise<void> {
+  const { logger, exitHandler, loadConfigFn, createClientFn, loadCacheFn, saveCacheFn } = {
+    ...defaultDeps,
+    ...deps,
+  };
+
+  let config: Config;
+  try {
+    config = loadConfigFn();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      logger.error(`${symbols.error()} ${colors.error('Configuration error:')} ${err.message}`);
+      if (err.configPath) {
+        logger.error(`  File: ${colors.path(err.configPath)}`);
+      }
+    } else {
+      logger.error(`${symbols.error()} ${colors.error('Failed to load configuration:')} ${String(err)}`);
+    }
+    exitHandler.exit(1);
+    return;
+  }
+
+  const resolved = resolveWorkspace(config, options.workspace);
+
+  if (!resolved) {
+    if (options.workspace) {
+      logger.error(
+        `${symbols.error()} ${colors.error('Workspace')} ${colors.emphasis(`"${options.workspace}"`)} ${colors.error('is not configured.')}`
+      );
+    } else if (Object.keys(config.workspaces).length === 0) {
+      logger.error(`${symbols.error()} ${colors.error('No workspaces configured.')}`);
+    } else {
+      logger.error(`${symbols.error()} ${colors.error('Multiple workspaces configured but no default set.')}`);
+      logger.error(colors.hint('Use --workspace <slug> to specify which workspace to use,'));
+      logger.error(colors.hint('or set "defaultWorkspace" in your configuration.'));
+    }
+    logger.error(colors.hint('Run "hscli setup" to configure your workspace.'));
+    exitHandler.exit(1);
+    return;
+  }
+
+  // Fetch all documents with caching
+  const documents = await fetchAllDocuments(resolved, {
+    createClientFn,
+    loadCacheFn,
+    saveCacheFn,
+  });
+
+  if (documents.length === 0) {
+    logger.log(`${symbols.info()} ${colors.hint('No documents found.')}`);
+    return;
+  }
+
+  // Display documents in a table format
+  logger.log('');
+  logger.log(`${colors.emphasis('Available Documents')} (${colors.success(String(documents.length))} total)`);
+  logger.log('');
+
+  // Calculate column widths
+  const maxSlugLength = Math.max(4, Math.max(...documents.map((d) => d.slug.length)));
+  const maxTitleLength = Math.max(5, Math.max(...documents.map((d) => d.title.length)));
+
+  // Print header
+  const slugHeader = 'SLUG'.padEnd(maxSlugLength);
+  const titleHeader = 'TITLE'.padEnd(maxTitleLength);
+  logger.log(`  ${colors.emphasis(slugHeader)}  ${colors.emphasis(titleHeader)}`);
+  logger.log(`  ${'-'.repeat(maxSlugLength)}  ${'-'.repeat(maxTitleLength)}`);
+
+  // Print rows
+  for (const doc of documents) {
+    const slugCol = doc.slug.padEnd(maxSlugLength);
+    const titleCol = doc.title.padEnd(maxTitleLength);
+    logger.log(`  ${colors.path(slugCol)}  ${titleCol}`);
+  }
+
+  logger.log('');
+}

--- a/packages/cli/src/actions/docs-show-action.ts
+++ b/packages/cli/src/actions/docs-show-action.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@hackersheet/core';
 
+import { loadDocumentCache, saveDocumentCache, type CachedDocument } from '../utils/cache';
 import { colors, symbols } from '../utils/colors';
 import { loadConfig, type Config, ConfigError } from '../utils/load-config';
 
@@ -26,6 +27,8 @@ export type DocsShowActionDeps = {
   exitHandler: ExitHandler;
   loadConfigFn: () => Config;
   createClientFn: typeof createClient;
+  loadDocumentCacheFn: typeof loadDocumentCache;
+  saveDocumentCacheFn: typeof saveDocumentCache;
 };
 
 const defaultDeps: DocsShowActionDeps = {
@@ -33,6 +36,8 @@ const defaultDeps: DocsShowActionDeps = {
   exitHandler: { exit: (code) => process.exit(code) },
   loadConfigFn: loadConfig,
   createClientFn: createClient,
+  loadDocumentCacheFn: loadDocumentCache,
+  saveDocumentCacheFn: saveDocumentCache,
 };
 
 /**
@@ -89,6 +94,8 @@ function resolveWorkspace(config: Config, workspaceOption?: string): ResolvedWor
 export type DocsShowActionOptions = {
   /** Workspace slug to use (overrides default). */
   workspace?: string;
+  /** Bypass cache and fetch from API, then update cache. */
+  refresh?: boolean;
 };
 
 /**
@@ -107,7 +114,10 @@ export async function docsShowAction(
   options: DocsShowActionOptions = {},
   deps: Partial<DocsShowActionDeps> = {}
 ): Promise<void> {
-  const { logger, exitHandler, loadConfigFn, createClientFn } = { ...defaultDeps, ...deps };
+  const { logger, exitHandler, loadConfigFn, createClientFn, loadDocumentCacheFn, saveDocumentCacheFn } = {
+    ...defaultDeps,
+    ...deps,
+  };
 
   if (!slug) {
     logger.error(`${symbols.error()} ${colors.error('Missing required argument')} ${colors.emphasis('<slug>')}`);
@@ -151,6 +161,16 @@ export async function docsShowAction(
     return;
   }
 
+  // Try to load from cache first (unless refresh is requested)
+  if (!options.refresh) {
+    const cached = loadDocumentCacheFn(resolved.slug, slug);
+    if (cached) {
+      logger.log(cached.content);
+      return;
+    }
+  }
+
+  // Cache miss or refresh requested: fetch from API
   const url = `https://api.hackersheet.com/${resolved.slug}/v1/graphql`;
   const client = createClientFn({
     url,
@@ -179,6 +199,18 @@ export async function docsShowAction(
     exitHandler.exit(1);
     return;
   }
+
+  // Save to cache (fire and forget)
+  const documentToCache: CachedDocument = {
+    id: result.document.id,
+    slug: result.document.slug,
+    title: result.document.title,
+    content: result.document.content,
+    draft: result.document.draft,
+  };
+  saveDocumentCacheFn(resolved.slug, slug, documentToCache).catch(() => {
+    // Silently ignore cache errors
+  });
 
   logger.log(result.document.content);
 }

--- a/packages/cli/src/actions/docs-show-action.ts
+++ b/packages/cli/src/actions/docs-show-action.ts
@@ -1,0 +1,184 @@
+import { createClient } from '@hackersheet/core';
+
+import { colors, symbols } from '../utils/colors';
+import { loadConfig, type Config, ConfigError } from '../utils/load-config';
+
+/**
+ * Logger interface for output, enabling dependency injection in tests.
+ */
+export type Logger = {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+/**
+ * Exit handler interface for process exit, enabling dependency injection in tests.
+ */
+export type ExitHandler = {
+  exit: (code?: number) => void;
+};
+
+/**
+ * Dependencies for the docsShowAction function.
+ */
+export type DocsShowActionDeps = {
+  logger: Logger;
+  exitHandler: ExitHandler;
+  loadConfigFn: () => Config;
+  createClientFn: typeof createClient;
+};
+
+const defaultDeps: DocsShowActionDeps = {
+  logger: { log: console.log, error: console.error },
+  exitHandler: { exit: (code) => process.exit(code) },
+  loadConfigFn: loadConfig,
+  createClientFn: createClient,
+};
+
+/**
+ * Resolved workspace information.
+ */
+type ResolvedWorkspace = {
+  slug: string;
+  accessKey: string;
+};
+
+/**
+ * Resolves the workspace to use based on options and config.
+ *
+ * Resolution order:
+ * 1. --workspace option if specified
+ * 2. defaultWorkspace if configured
+ * 3. Single workspace if only one exists
+ * 4. null if none of the above
+ *
+ * @param config - The loaded configuration.
+ * @param workspaceOption - The workspace slug from CLI option.
+ * @returns The resolved workspace or null.
+ */
+function resolveWorkspace(config: Config, workspaceOption?: string): ResolvedWorkspace | null {
+  const workspaceSlugs = Object.keys(config.workspaces);
+
+  // 1. --workspace option specified
+  if (workspaceOption) {
+    const workspace = config.workspaces[workspaceOption];
+    if (!workspace) return null;
+    return { slug: workspaceOption, accessKey: workspace.accessKey };
+  }
+
+  // 2. defaultWorkspace configured
+  if (config.defaultWorkspace) {
+    const workspace = config.workspaces[config.defaultWorkspace];
+    if (!workspace) return null;
+    return { slug: config.defaultWorkspace, accessKey: workspace.accessKey };
+  }
+
+  // 3. Single workspace auto-select
+  if (workspaceSlugs.length === 1) {
+    const slug = workspaceSlugs[0];
+    return { slug, accessKey: config.workspaces[slug].accessKey };
+  }
+
+  // 4. Unable to resolve
+  return null;
+}
+
+/**
+ * Options for the docs action.
+ */
+export type DocsShowActionOptions = {
+  /** Workspace slug to use (overrides default). */
+  workspace?: string;
+};
+
+/**
+ * Fetches and displays a document by its slug.
+ *
+ * This is the action handler for the `docs show` command.
+ * Retrieves document content from the Hacker Sheet API using the
+ * configured workspace credentials.
+ *
+ * @param slug - The document slug to fetch.
+ * @param options - Command options including workspace selection.
+ * @param deps - Optional dependencies for testing.
+ */
+export async function docsShowAction(
+  slug: string,
+  options: DocsShowActionOptions = {},
+  deps: Partial<DocsShowActionDeps> = {}
+): Promise<void> {
+  const { logger, exitHandler, loadConfigFn, createClientFn } = { ...defaultDeps, ...deps };
+
+  if (!slug) {
+    logger.error(`${symbols.error()} ${colors.error('Missing required argument')} ${colors.emphasis('<slug>')}`);
+    logger.error(`${colors.hint('Usage: hscli docs <slug>')}`);
+    exitHandler.exit(1);
+    return;
+  }
+
+  let config: Config;
+  try {
+    config = loadConfigFn();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      logger.error(`${symbols.error()} ${colors.error('Configuration error:')} ${err.message}`);
+      if (err.configPath) {
+        logger.error(`  File: ${colors.path(err.configPath)}`);
+      }
+    } else {
+      logger.error(`${symbols.error()} ${colors.error('Failed to load configuration:')} ${String(err)}`);
+    }
+    exitHandler.exit(1);
+    return;
+  }
+
+  const resolved = resolveWorkspace(config, options.workspace);
+
+  if (!resolved) {
+    if (options.workspace) {
+      logger.error(
+        `${symbols.error()} ${colors.error('Workspace')} ${colors.emphasis(`"${options.workspace}"`)} ${colors.error('is not configured.')}`
+      );
+    } else if (Object.keys(config.workspaces).length === 0) {
+      logger.error(`${symbols.error()} ${colors.error('No workspaces configured.')}`);
+    } else {
+      logger.error(`${symbols.error()} ${colors.error('Multiple workspaces configured but no default set.')}`);
+      logger.error(colors.hint('Use --workspace <slug> to specify which workspace to use,'));
+      logger.error(colors.hint('or set "defaultWorkspace" in your configuration.'));
+    }
+    logger.error(colors.hint('Run "hscli setup" to configure your workspace.'));
+    exitHandler.exit(1);
+    return;
+  }
+
+  const url = `https://api.hackersheet.com/${resolved.slug}/v1/graphql`;
+  const client = createClientFn({
+    url,
+    accessKey: resolved.accessKey,
+  });
+
+  let result;
+  try {
+    result = await client.getDocument({ slug });
+  } catch (err) {
+    logger.error(`${symbols.error()} ${colors.error('Failed to connect to the API.')}`);
+    logger.error(`  ${colors.dim('Details:')} ${String(err)}`);
+    exitHandler.exit(1);
+    return;
+  }
+
+  if (result.error) {
+    logger.error(`${symbols.error()} ${colors.error('API returned an error.')}`);
+    logger.error(`  ${colors.dim('Details:')} ${String(result.error)}`);
+    exitHandler.exit(1);
+    return;
+  }
+
+  if (result.document?.content === undefined) {
+    logger.error(`${symbols.error()} ${colors.error('Document not found with slug')} ${colors.emphasis(`"${slug}"`)}`);
+    exitHandler.exit(1);
+    return;
+  }
+
+  logger.log(result.document.content);
+}

--- a/packages/cli/src/actions/init-action.ts
+++ b/packages/cli/src/actions/init-action.ts
@@ -1,0 +1,111 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import { input, confirm } from '@inquirer/prompts';
+
+import { runConfigWizard, type ConfigInitActionDeps } from './config';
+import { colors, symbols } from '../utils/colors';
+import { loadUserConfig, loadConfigFromPath } from '../utils/load-config';
+import { saveConfig } from '../utils/save-config';
+
+/**
+ * Minimal filesystem interface for dependency injection.
+ */
+export type FsLike = {
+  mkdir: typeof fs.mkdir;
+  writeFile: typeof fs.writeFile;
+  access: typeof fs.access;
+};
+
+/**
+ * Interface for user prompts, enabling dependency injection in tests.
+ */
+export type Prompts = {
+  input: typeof input;
+  confirm: typeof confirm;
+};
+
+/**
+ * Logger interface for output, enabling dependency injection in tests.
+ */
+export type Logger = {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+/**
+ * Dependencies for the initAction function.
+ */
+export type InitActionDeps = {
+  fsApi: FsLike;
+  prompts: Prompts;
+  logger: Logger;
+  cwd: () => string;
+  configInitDeps?: Partial<ConfigInitActionDeps>;
+};
+
+const defaultDeps: InitActionDeps = {
+  fsApi: fs,
+  prompts: { input, confirm },
+  logger: { log: console.log, error: console.error },
+  cwd: () => process.cwd(),
+};
+
+/**
+ * Initializes Hacker Sheet in the current project.
+ *
+ * This is the action handler for the `init` command.
+ * Creates the `.hackersheet` directory and `cli.config.json` configuration
+ * file with project-specific settings.
+ *
+ * @param deps - Optional dependencies for testing.
+ */
+export async function initAction(deps: Partial<InitActionDeps> = {}): Promise<void> {
+  const { fsApi, prompts, logger, cwd, configInitDeps } = { ...defaultDeps, ...deps };
+
+  // Validate that setup has been run
+  const userConfig = loadUserConfig();
+  if (!userConfig.workspaces || Object.keys(userConfig.workspaces).length === 0) {
+    logger.error(`${symbols.error()} ${colors.error('No workspaces configured.')}`);
+    logger.error(`   ${colors.hint('Run')} ${colors.emphasis('hscli setup')} ${colors.hint('first.')}`);
+    return;
+  }
+
+  const projectRoot = cwd();
+  const hackersheetDir = path.join(projectRoot, '.hackersheet');
+  const configPath = path.join(hackersheetDir, 'cli.config.json');
+  const treesDir = path.join(hackersheetDir, 'trees');
+
+  const wizardDeps: Partial<ConfigInitActionDeps> = {
+    fsApi: { mkdir: fsApi.mkdir, access: fsApi.access },
+    prompts,
+    logger,
+    loadConfigFromPath,
+    saveConfig,
+    ...configInitDeps,
+  };
+
+  const wizardOptions = {
+    confirmMessage: 'Project is already initialized. Overwrite configuration?',
+    headerMessage: '\nHacker Sheet Project Initialization\n',
+  };
+
+  const result = await runConfigWizard(configPath, 'project', wizardDeps, wizardOptions);
+
+  if (result.cancelled) {
+    logger.log(`${symbols.warning()} ${colors.warning('Initialization cancelled.')}`);
+    return;
+  }
+
+  // Create directories
+  await fsApi.mkdir(hackersheetDir, { recursive: true });
+  await fsApi.mkdir(treesDir, { recursive: true });
+
+  // Write configuration
+  const configJson = JSON.stringify(result.config, null, 2);
+  await fsApi.writeFile(configPath, configJson, 'utf8');
+
+  logger.log(`\n${symbols.success()} ${colors.success('Project initialization completed!')}`);
+  logger.log(`   Created: ${colors.path(hackersheetDir)}`);
+  logger.log(`   Config:  ${colors.path(configPath)}`);
+}

--- a/packages/cli/src/actions/new-action.ts
+++ b/packages/cli/src/actions/new-action.ts
@@ -69,6 +69,14 @@ export async function newAction(deps: Partial<NewActionDeps> = {}): Promise<void
   const { fsApi, prompts, logger, loadConfigFn, findRootFn, getDateFn } = { ...defaultDeps, ...deps };
 
   const config = loadConfigFn();
+
+  // Validate project initialization
+  if (!config.docsDirs || config.docsDirs.length === 0) {
+    logger.error(`${symbols.error()} ${colors.error('Project not initialized.')}`);
+    logger.error(`   ${colors.hint('Run')} ${colors.emphasis('hscli init')} ${colors.hint('first.')}`);
+    return;
+  }
+
   const projectRootPath = findRootFn() || process.cwd();
 
   const title = (await prompts.input({ message: 'Enter title' })) as string;

--- a/packages/cli/src/actions/setup-action.ts
+++ b/packages/cli/src/actions/setup-action.ts
@@ -5,7 +5,7 @@ import { input, confirm } from '@inquirer/prompts';
 
 import { runConfigWizard, type ConfigInitActionDeps } from './config';
 import { colors, symbols } from '../utils/colors';
-import { loadConfigFromPath } from '../utils/load-config';
+import { getUserConfigPath, loadConfigFromPath } from '../utils/load-config';
 import { saveConfig } from '../utils/save-config';
 
 /**
@@ -52,21 +52,18 @@ const defaultDeps: SetupActionDeps = {
 };
 
 /**
- * Initializes Hacker Sheet in the current project.
+ * Initializes global configuration for Hacker Sheet.
  *
  * This is the action handler for the `setup` command.
- * Creates the `.hackersheet` directory and `cli.config.json` configuration
- * file with user-provided settings.
+ * Creates the user config directory and `cli.config.json` configuration
+ * file with workspace settings.
  *
  * @param deps - Optional dependencies for testing.
  */
 export async function setupAction(deps: Partial<SetupActionDeps> = {}): Promise<void> {
-  const { fsApi, prompts, logger, cwd, configInitDeps } = { ...defaultDeps, ...deps };
+  const { fsApi, prompts, logger, configInitDeps } = { ...defaultDeps, ...deps };
 
-  const projectRoot = cwd();
-  const hackersheetDir = path.join(projectRoot, '.hackersheet');
-  const configPath = path.join(hackersheetDir, 'cli.config.json');
-  const treesDir = path.join(hackersheetDir, 'trees');
+  const configPath = getUserConfigPath();
 
   const wizardDeps: Partial<ConfigInitActionDeps> = {
     fsApi: { mkdir: fsApi.mkdir, access: fsApi.access },
@@ -78,29 +75,28 @@ export async function setupAction(deps: Partial<SetupActionDeps> = {}): Promise<
   };
 
   const wizardOptions = {
-    confirmMessage: 'Hacker Sheet is already initialized. Overwrite configuration?',
+    confirmMessage: 'Hacker Sheet is already set up. Overwrite configuration?',
     headerMessage: '\nHacker Sheet CLI Setup\n',
   };
 
-  const result = await runConfigWizard(configPath, wizardDeps, wizardOptions);
+  const result = await runConfigWizard(configPath, 'global', wizardDeps, wizardOptions);
 
   if (result.cancelled) {
     logger.log(`${symbols.warning()} ${colors.warning('Setup cancelled.')}`);
     return;
   }
 
-  // Create directories
-  await fsApi.mkdir(hackersheetDir, { recursive: true });
-  await fsApi.mkdir(treesDir, { recursive: true });
+  // Create config directory
+  const configDir = path.dirname(configPath);
+  await fsApi.mkdir(configDir, { recursive: true });
 
   // Write configuration
   const configJson = JSON.stringify(result.config, null, 2);
   await fsApi.writeFile(configPath, configJson, 'utf8');
 
   logger.log(`\n${symbols.success()} ${colors.success('Setup completed!')}`);
-  logger.log(`   Created: ${colors.path(hackersheetDir)}`);
-  logger.log(`   Config:  ${colors.path(configPath)}`);
+  logger.log(`   Config: ${colors.path(configPath)}`);
   logger.log(
-    `\n${symbols.info()} ${colors.hint('Tip: Enable tab completion with')} ${colors.emphasis('hscli completion install')}`
+    `\n${symbols.info()} ${colors.hint('Next: Run')} ${colors.emphasis('hscli init')} ${colors.hint('in your project')}`
   );
 }

--- a/packages/cli/src/actions/setup-action.ts
+++ b/packages/cli/src/actions/setup-action.ts
@@ -100,4 +100,7 @@ export async function setupAction(deps: Partial<SetupActionDeps> = {}): Promise<
   logger.log(`\n${symbols.success()} ${colors.success('Setup completed!')}`);
   logger.log(`   Created: ${colors.path(hackersheetDir)}`);
   logger.log(`   Config:  ${colors.path(configPath)}`);
+  logger.log(
+    `\n${symbols.info()} ${colors.hint('Tip: Enable tab completion with')} ${colors.emphasis('hscli completion install')}`
+  );
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -83,6 +83,7 @@ docsCommand
   .command('show <slug>')
   .description('Fetch and display document content by slug.')
   .option('-w, --workspace <slug>', 'Workspace to use')
+  .option('--refresh', 'Bypass cache and fetch from API')
   .action((slug, options) => docsShowAction(slug, options));
 
 program.command('new').description('Create a new document.').action(newAction);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,8 @@ import {
   configPathAction,
   configInitAction,
 } from './actions/config';
-import { docsAction } from './actions/docs-action';
+import { docsListAction } from './actions/docs-list-action';
+import { docsShowAction } from './actions/docs-show-action';
 import { genTreeAction } from './actions/gen-tree-action';
 import { newAction } from './actions/new-action';
 import { setupAction } from './actions/setup-action';
@@ -66,11 +67,21 @@ program
   .option('--no-color', 'Disable colored output');
 
 program.command('setup').description('Setup Hacker Sheet in the current project.').action(setupAction);
-program
-  .command('docs <slug>')
-  .description('Fetch document content by slug.')
+
+const docsCommand = program.command('docs').description('Manage documents.');
+
+docsCommand
+  .command('list')
+  .description('List all available documents with their slugs and titles.')
   .option('-w, --workspace <slug>', 'Workspace to use')
-  .action((slug, options) => docsAction(slug, options));
+  .action((options) => docsListAction(options));
+
+docsCommand
+  .command('show <slug>')
+  .description('Fetch and display document content by slug.')
+  .option('-w, --workspace <slug>', 'Workspace to use')
+  .action((slug, options) => docsShowAction(slug, options));
+
 program.command('new').description('Create a new document.').action(newAction);
 program
   .command('gen:tree')

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -134,14 +134,16 @@ cacheCommand
   .action(() => cacheClearAction());
 
 // Handle shell tab completion
-if (process.env.COMP_CWORD !== undefined || process.env.COMP_LINE !== undefined) {
-  (async () => {
+const isCompletionMode = process.env.COMP_CWORD !== undefined || process.env.COMP_LINE !== undefined;
+
+if (isCompletionMode) {
+  try {
     await completionHandler();
     process.exit(0);
-  })().catch((error) => {
+  } catch (error) {
     console.error(error);
     process.exit(1);
-  });
+  }
 } else {
   program.parse();
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'url';
 
 import { Command } from 'commander';
 
+import { cacheClearAction } from './actions/cache/cache-clear-action';
+import { completionInstallAction } from './actions/completion/completion-install-action';
 import {
   configListAction,
   configGetAction,
@@ -16,6 +18,7 @@ import { docsAction } from './actions/docs-action';
 import { genTreeAction } from './actions/gen-tree-action';
 import { newAction } from './actions/new-action';
 import { setupAction } from './actions/setup-action';
+import { completionHandler } from './completion-handler';
 import { setNoColor, colors, symbols } from './utils/colors';
 
 /**
@@ -116,4 +119,29 @@ configCommand
   .option('-l, --local', 'Show only project configuration path')
   .action((options) => configPathAction(options));
 
-program.parse();
+const completionCommand = program.command('completion').description('Manage shell completion.');
+
+completionCommand
+  .command('install')
+  .description('Install shell completion.')
+  .action(() => completionInstallAction());
+
+const cacheCommand = program.command('cache').description('Manage CLI cache.');
+
+cacheCommand
+  .command('clear')
+  .description('Clear slugs cache.')
+  .action(() => cacheClearAction());
+
+// Handle shell tab completion
+if (process.env.COMP_CWORD !== undefined || process.env.COMP_LINE !== undefined) {
+  (async () => {
+    await completionHandler();
+    process.exit(0);
+  })().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+} else {
+  program.parse();
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -128,9 +128,10 @@ configCommand
 
 configCommand
   .command('path')
-  .description('Show configuration file paths.')
+  .description('Show configuration file and cache directory paths.')
   .option('-g, --global', 'Show only user configuration path')
   .option('-l, --local', 'Show only project configuration path')
+  .option('-c, --cache', 'Show only cache directory path')
   .action((options) => configPathAction(options));
 
 const completionCommand = program.command('completion').description('Manage shell completion.');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ import {
 import { docsListAction } from './actions/docs-list-action';
 import { docsShowAction } from './actions/docs-show-action';
 import { genTreeAction } from './actions/gen-tree-action';
+import { initAction } from './actions/init-action';
 import { newAction } from './actions/new-action';
 import { setupAction } from './actions/setup-action';
 import { completionHandler } from './completion-handler';
@@ -66,7 +67,9 @@ program
   .version(getVersion())
   .option('--no-color', 'Disable colored output');
 
-program.command('setup').description('Setup Hacker Sheet in the current project.').action(setupAction);
+program.command('setup').description('Setup global Hacker Sheet configuration.').action(setupAction);
+
+program.command('init').description('Initialize Hacker Sheet in the current project.').action(initAction);
 
 const docsCommand = program.command('docs').description('Manage documents.');
 

--- a/packages/cli/src/completion-handler.ts
+++ b/packages/cli/src/completion-handler.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@hackersheet/core';
 import tabtab from '@pnpm/tabtab';
 
-import { loadCache, saveCache } from './utils/cache';
+import { loadCache, saveCache, type DocumentCacheItem } from './utils/cache';
 import { loadConfig, type Config } from './utils/load-config';
 
 /**
@@ -18,8 +18,8 @@ type ResolvedWorkspace = {
 export type CompletionHandlerDeps = {
   loadConfigFn: () => Config;
   createClientFn: typeof createClient;
-  loadCacheFn: (workspace: string) => string[] | null;
-  saveCacheFn: (workspace: string, slugs: string[]) => Promise<void>;
+  loadCacheFn: (workspace: string) => DocumentCacheItem[] | null;
+  saveCacheFn: (workspace: string, documents: DocumentCacheItem[]) => Promise<void>;
 };
 
 const defaultDeps: CompletionHandlerDeps = {
@@ -91,13 +91,16 @@ function extractWorkspaceFromLine(line: string): string | undefined {
 }
 
 /**
- * Fetches document slugs from cache or API.
+ * Fetches documents from cache or API.
  *
  * @param workspace - The resolved workspace.
  * @param deps - Partial dependencies for testing.
- * @returns Array of document slugs.
+ * @returns Array of documents with slug and title.
  */
-async function getDocumentSlugs(workspace: ResolvedWorkspace, deps: Partial<CompletionHandlerDeps>): Promise<string[]> {
+async function getDocuments(
+  workspace: ResolvedWorkspace,
+  deps: Partial<CompletionHandlerDeps>
+): Promise<DocumentCacheItem[]> {
   const { createClientFn, loadCacheFn, saveCacheFn } = {
     ...defaultDeps,
     ...deps,
@@ -125,14 +128,17 @@ async function getDocumentSlugs(workspace: ResolvedWorkspace, deps: Partial<Comp
       return [];
     }
 
-    const slugs = documents.map((doc) => doc.slug);
+    const documentsData: DocumentCacheItem[] = documents.map((doc) => ({
+      slug: doc.slug,
+      title: doc.title,
+    }));
 
     // 3. Save to cache (fire and forget)
-    saveCacheFn(workspace.slug, slugs).catch(() => {
+    saveCacheFn(workspace.slug, documentsData).catch(() => {
       // Silently ignore cache errors
     });
 
-    return slugs;
+    return documentsData;
   } catch {
     return [];
   }
@@ -174,8 +180,12 @@ export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {
       const workspace = resolveWorkspace(config, workspaceOption);
 
       if (workspace) {
-        const slugs = await getDocumentSlugs(workspace, deps);
-        return tabtab.log(slugs);
+        const documents = await getDocuments(workspace, deps);
+        const completionItems = documents.map((doc) => ({
+          name: doc.slug,
+          description: doc.title,
+        }));
+        return tabtab.log(completionItems);
       }
     }
 

--- a/packages/cli/src/completion-handler.ts
+++ b/packages/cli/src/completion-handler.ts
@@ -195,6 +195,11 @@ export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {
       return tabtab.log(workspaceSlugs);
     }
 
+    // docs subcommand completion: hscli docs <TAB>
+    if (env.prev === 'docs') {
+      return tabtab.log(['show', 'list']);
+    }
+
     // docs show command slug completion: hscli docs show <TAB>
     if (env.line.includes('docs show') && config) {
       const workspaceOption = extractWorkspaceFromLine(env.line);

--- a/packages/cli/src/completion-handler.ts
+++ b/packages/cli/src/completion-handler.ts
@@ -13,6 +13,13 @@ type ResolvedWorkspace = {
 };
 
 /**
+ * Configuration for a command's subcommands.
+ */
+type CommandConfig = {
+  subcommands?: string[];
+};
+
+/**
  * Dependencies for the completionHandler function.
  */
 export type CompletionHandlerDeps = {
@@ -28,6 +35,24 @@ const defaultDeps: CompletionHandlerDeps = {
   loadCacheFn: loadCache,
   saveCacheFn: saveCache,
 };
+
+/**
+ * Mapping of top-level commands to their subcommands.
+ */
+const COMMAND_SUBCOMMANDS: Record<string, CommandConfig> = {
+  docs: { subcommands: ['show', 'list'] },
+  config: { subcommands: ['init', 'list', 'get', 'set', 'delete', 'path'] },
+  completion: { subcommands: ['install'] },
+  cache: { subcommands: ['clear'] },
+  setup: {},
+  init: {},
+  new: {},
+};
+
+/**
+ * All top-level commands available in the CLI.
+ */
+const ALL_COMMANDS = ['docs', 'new', 'setup', 'init', 'config', 'completion', 'cache', '--help', '--version'];
 
 /**
  * Resolves the workspace to use based on options and config.
@@ -166,6 +191,17 @@ async function getDocuments(
 }
 
 /**
+ * Completes subcommands for a given command.
+ *
+ * @param command - The command name.
+ * @returns Array of subcommand suggestions or empty array.
+ */
+function getSubcommandSuggestions(command: string): string[] {
+  const cmdConfig = COMMAND_SUBCOMMANDS[command];
+  return cmdConfig?.subcommands ?? [];
+}
+
+/**
  * Handles shell tab completion for the hscli command.
  *
  * This function is called by the shell completion system and provides
@@ -189,15 +225,16 @@ export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {
       // Config not available, proceed with basic completion
     }
 
-    // Workspace option completion: hscli docs -w <TAB> or hscli --workspace <TAB>
+    // Workspace option completion: hscli <command> -w <TAB> or hscli <command> --workspace <TAB>
     if ((env.prev === '--workspace' || env.prev === '-w') && config) {
       const workspaceSlugs = Object.keys(config.workspaces);
       return tabtab.log(workspaceSlugs);
     }
 
-    // docs subcommand completion: hscli docs <TAB>
-    if (env.prev === 'docs') {
-      return tabtab.log(['show', 'list']);
+    // Subcommand completion for any command: hscli <command> <TAB>
+    const subcommands = getSubcommandSuggestions(env.prev);
+    if (subcommands.length > 0) {
+      return tabtab.log(subcommands);
     }
 
     // docs show command slug completion: hscli docs show <TAB>
@@ -216,8 +253,7 @@ export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {
     }
 
     // Default command completion
-    const commands = ['docs', 'new', 'setup', 'config', 'completion', 'cache', '--help', '--version'];
-    return tabtab.log(commands);
+    return tabtab.log(ALL_COMMANDS);
   } catch {
     // Silently fail on errors to avoid breaking the shell
     return;

--- a/packages/cli/src/completion-handler.ts
+++ b/packages/cli/src/completion-handler.ts
@@ -1,0 +1,201 @@
+import { createClient } from '@hackersheet/core';
+import tabtab from '@pnpm/tabtab';
+
+import { loadCache, saveCache } from './utils/cache';
+import { loadConfig, type Config } from './utils/load-config';
+
+/**
+ * Resolved workspace information.
+ */
+type ResolvedWorkspace = {
+  slug: string;
+  accessKey: string;
+};
+
+/**
+ * Dependencies for the completionHandler function.
+ */
+export type CompletionHandlerDeps = {
+  loadConfigFn: () => Config;
+  createClientFn: typeof createClient;
+  loadCacheFn: (workspace: string) => string[] | null;
+  saveCacheFn: (workspace: string, slugs: string[]) => Promise<void>;
+};
+
+const defaultDeps: CompletionHandlerDeps = {
+  loadConfigFn: loadConfig,
+  createClientFn: createClient,
+  loadCacheFn: loadCache,
+  saveCacheFn: saveCache,
+};
+
+/**
+ * Resolves the workspace to use based on options and config.
+ *
+ * Resolution order:
+ * 1. --workspace option if specified
+ * 2. defaultWorkspace if configured
+ * 3. Single workspace if only one exists
+ * 4. null if none of the above
+ *
+ * @param config - The loaded configuration.
+ * @param workspaceOption - The workspace slug from CLI option.
+ * @returns The resolved workspace or null.
+ */
+function resolveWorkspace(config: Config, workspaceOption?: string): ResolvedWorkspace | null {
+  const workspaceSlugs = Object.keys(config.workspaces);
+
+  // 1. --workspace option specified
+  if (workspaceOption) {
+    const workspace = config.workspaces[workspaceOption];
+    if (!workspace) return null;
+    return {
+      slug: workspaceOption,
+      accessKey: workspace.accessKey,
+    };
+  }
+
+  // 2. defaultWorkspace configured
+  if (config.defaultWorkspace) {
+    const workspace = config.workspaces[config.defaultWorkspace];
+    if (!workspace) return null;
+    return {
+      slug: config.defaultWorkspace,
+      accessKey: workspace.accessKey,
+    };
+  }
+
+  // 3. Single workspace auto-select
+  if (workspaceSlugs.length === 1) {
+    const slug = workspaceSlugs[0];
+    const workspace = config.workspaces[slug];
+    return {
+      slug,
+      accessKey: workspace.accessKey,
+    };
+  }
+
+  // 4. Unable to resolve
+  return null;
+}
+
+/**
+ * Extracts the workspace slug from the command line.
+ *
+ * @param line - The command line string.
+ * @returns The workspace slug if found, undefined otherwise.
+ */
+function extractWorkspaceFromLine(line: string): string | undefined {
+  const workspaceMatch = line.match(/(?:-w|--workspace)\s+(\S+)/);
+  return workspaceMatch?.[1];
+}
+
+/**
+ * Fetches document slugs from cache or API.
+ *
+ * @param workspace - The resolved workspace.
+ * @param deps - Partial dependencies for testing.
+ * @returns Array of document slugs.
+ */
+async function getDocumentSlugs(workspace: ResolvedWorkspace, deps: Partial<CompletionHandlerDeps>): Promise<string[]> {
+  const { createClientFn, loadCacheFn, saveCacheFn } = {
+    ...defaultDeps,
+    ...deps,
+  };
+
+  // 1. Try to load from cache
+  const cached = loadCacheFn(workspace.slug);
+  if (cached) {
+    return cached;
+  }
+
+  // 2. Fetch from API
+  try {
+    const url = `https://api.hackersheet.com/${workspace.slug}/v1/graphql`;
+    const client = createClientFn({
+      url,
+      accessKey: workspace.accessKey,
+    });
+
+    const { documents, error } = await client.getDocuments({
+      filter: { draft: false },
+    });
+
+    if (error || !documents) {
+      return [];
+    }
+
+    const slugs = documents.map((doc) => doc.slug);
+
+    // 3. Save to cache (fire and forget)
+    saveCacheFn(workspace.slug, slugs).catch(() => {
+      // Silently ignore cache errors
+    });
+
+    return slugs;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Handles shell tab completion for the hscli command.
+ *
+ * This function is called by the shell completion system and provides
+ * intelligent completion suggestions based on the command being typed.
+ *
+ * @param deps - Optional dependencies for testing.
+ */
+export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {}): Promise<void> {
+  const env = tabtab.parseEnv(process.env);
+
+  // If not in completion mode, exit early
+  if (!env.complete) {
+    return;
+  }
+
+  try {
+    let config: Config | null = null;
+    try {
+      config = (deps.loadConfigFn || defaultDeps.loadConfigFn)();
+    } catch {
+      // Config not available, proceed with basic completion
+    }
+
+    // Workspace option completion: hscli docs -w <TAB> or hscli --workspace <TAB>
+    if (
+      (env.prev === '--workspace' || env.prev === '-w') &&
+      config
+    ) {
+      const workspaceSlugs = Object.keys(config.workspaces);
+      return tabtab.log(workspaceSlugs);
+    }
+
+    // docs command slug completion: hscli docs <TAB>
+    if (env.line.includes('docs') && config) {
+      const workspaceOption = extractWorkspaceFromLine(env.line);
+      const workspace = resolveWorkspace(config, workspaceOption);
+
+      if (workspace) {
+        const slugs = await getDocumentSlugs(workspace, deps);
+        return tabtab.log(slugs);
+      }
+    }
+
+    // Default command completion
+    const commands = [
+      'docs',
+      'new',
+      'setup',
+      'config',
+      'completion',
+      'cache',
+      '--help',
+      '--version',
+    ];
+    return tabtab.log(commands);
+  } catch {
+    // Silently fail on errors to avoid breaking the shell
+    return;
+  }
+}

--- a/packages/cli/src/completion-handler.ts
+++ b/packages/cli/src/completion-handler.ts
@@ -91,7 +91,7 @@ function extractWorkspaceFromLine(line: string): string | undefined {
 }
 
 /**
- * Fetches documents from cache or API.
+ * Fetches all documents from cache or API using cursor-based pagination.
  *
  * @param workspace - The resolved workspace.
  * @param deps - Partial dependencies for testing.
@@ -112,7 +112,7 @@ async function getDocuments(
     return cached;
   }
 
-  // 2. Fetch from API
+  // 2. Fetch from API with cursor-based pagination to get all documents
   try {
     const url = `https://api.hackersheet.com/${workspace.slug}/v1/graphql`;
     const client = createClientFn({
@@ -120,25 +120,46 @@ async function getDocuments(
       accessKey: workspace.accessKey,
     });
 
-    const { documents, error } = await client.getDocuments({
-      filter: { draft: false },
-    });
+    const allDocuments: DocumentCacheItem[] = [];
+    let after: string | undefined = undefined;
+    const pageSize = 100; // Fetch 100 documents per request
 
-    if (error || !documents) {
-      return [];
+    // Iterate through all pages
+    while (true) {
+      const { documents, error } = await client.getDocuments({
+        filter: { draft: false },
+        first: pageSize,
+        after,
+      });
+
+      if (error || !documents || documents.length === 0) {
+        break;
+      }
+
+      // Extract slug and title from each document
+      const batch: DocumentCacheItem[] = documents.map((doc) => ({
+        slug: doc.slug,
+        title: doc.title,
+      }));
+
+      allDocuments.push(...batch);
+
+      // If we got fewer documents than the page size, we've reached the end
+      if (documents.length < pageSize) {
+        break;
+      }
+
+      // Prepare for the next page: use the last document's ID as the cursor
+      const lastDoc = documents[documents.length - 1];
+      after = lastDoc.id; // Use document ID as cursor for next page
     }
 
-    const documentsData: DocumentCacheItem[] = documents.map((doc) => ({
-      slug: doc.slug,
-      title: doc.title,
-    }));
-
     // 3. Save to cache (fire and forget)
-    saveCacheFn(workspace.slug, documentsData).catch(() => {
+    saveCacheFn(workspace.slug, allDocuments).catch(() => {
       // Silently ignore cache errors
     });
 
-    return documentsData;
+    return allDocuments;
   } catch {
     return [];
   }

--- a/packages/cli/src/completion-handler.ts
+++ b/packages/cli/src/completion-handler.ts
@@ -157,16 +157,13 @@ export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {
   try {
     let config: Config | null = null;
     try {
-      config = (deps.loadConfigFn || defaultDeps.loadConfigFn)();
+      config = (deps.loadConfigFn ?? defaultDeps.loadConfigFn)();
     } catch {
       // Config not available, proceed with basic completion
     }
 
     // Workspace option completion: hscli docs -w <TAB> or hscli --workspace <TAB>
-    if (
-      (env.prev === '--workspace' || env.prev === '-w') &&
-      config
-    ) {
+    if ((env.prev === '--workspace' || env.prev === '-w') && config) {
       const workspaceSlugs = Object.keys(config.workspaces);
       return tabtab.log(workspaceSlugs);
     }
@@ -183,16 +180,7 @@ export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {
     }
 
     // Default command completion
-    const commands = [
-      'docs',
-      'new',
-      'setup',
-      'config',
-      'completion',
-      'cache',
-      '--help',
-      '--version',
-    ];
+    const commands = ['docs', 'new', 'setup', 'config', 'completion', 'cache', '--help', '--version'];
     return tabtab.log(commands);
   } catch {
     // Silently fail on errors to avoid breaking the shell

--- a/packages/cli/src/completion-handler.ts
+++ b/packages/cli/src/completion-handler.ts
@@ -195,8 +195,8 @@ export async function completionHandler(deps: Partial<CompletionHandlerDeps> = {
       return tabtab.log(workspaceSlugs);
     }
 
-    // docs command slug completion: hscli docs <TAB>
-    if (env.line.includes('docs') && config) {
+    // docs show command slug completion: hscli docs show <TAB>
+    if (env.line.includes('docs show') && config) {
       const workspaceOption = extractWorkspaceFromLine(env.line);
       const workspace = resolveWorkspace(config, workspaceOption);
 

--- a/packages/cli/src/types/logger.ts
+++ b/packages/cli/src/types/logger.ts
@@ -1,0 +1,7 @@
+/**
+ * Logger interface for output, enabling dependency injection in tests.
+ */
+export type Logger = {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};

--- a/packages/cli/src/utils/__tests__/cache.unit.test.ts
+++ b/packages/cli/src/utils/__tests__/cache.unit.test.ts
@@ -8,7 +8,8 @@ import {
   getCachePath,
   isCacheValid,
   type CacheDeps,
-  type SlugsCacheEntry,
+  type DocumentsCacheEntry,
+  type DocumentCacheItem,
 } from '../cache';
 
 describe('cache utilities', () => {
@@ -65,8 +66,8 @@ describe('cache utilities', () => {
 
   describe('isCacheValid', () => {
     it('returns true if cache is within TTL', () => {
-      const entry: SlugsCacheEntry = {
-        slugs: ['doc1'],
+      const entry: DocumentsCacheEntry = {
+        documents: [{ slug: 'doc1', title: 'Doc 1' }],
         timestamp: 1000,
         workspace: 'test-workspace',
       };
@@ -79,8 +80,8 @@ describe('cache utilities', () => {
     });
 
     it('returns false if cache is expired', () => {
-      const entry: SlugsCacheEntry = {
-        slugs: ['doc1'],
+      const entry: DocumentsCacheEntry = {
+        documents: [{ slug: 'doc1', title: 'Doc 1' }],
         timestamp: 1000,
         workspace: 'test-workspace',
       };
@@ -93,8 +94,8 @@ describe('cache utilities', () => {
     });
 
     it('returns true if cache timestamp equals now - ttl', () => {
-      const entry: SlugsCacheEntry = {
-        slugs: ['doc1'],
+      const entry: DocumentsCacheEntry = {
+        documents: [{ slug: 'doc1', title: 'Doc 1' }],
         timestamp: 0,
         workspace: 'test-workspace',
       };
@@ -128,7 +129,10 @@ describe('cache utilities', () => {
       const oldTimestamp = 1000;
       const cacheContent = JSON.stringify({
         'test-workspace': {
-          slugs: ['doc1', 'doc2'],
+          documents: [
+            { slug: 'doc1', title: 'Doc 1' },
+            { slug: 'doc2', title: 'Doc 2' },
+          ],
           timestamp: oldTimestamp,
           workspace: 'test-workspace',
         },
@@ -148,11 +152,16 @@ describe('cache utilities', () => {
       expect(result).toBeNull();
     });
 
-    it('returns cached slugs when cache is valid', () => {
+    it('returns cached documents when cache is valid', () => {
       const timestamp = 1000000;
+      const documents: DocumentCacheItem[] = [
+        { slug: 'doc1', title: 'Doc 1' },
+        { slug: 'doc2', title: 'Doc 2' },
+        { slug: 'doc3', title: 'Doc 3' },
+      ];
       const cacheContent = JSON.stringify({
         'test-workspace': {
-          slugs: ['doc1', 'doc2', 'doc3'],
+          documents,
           timestamp,
           workspace: 'test-workspace',
         },
@@ -169,13 +178,13 @@ describe('cache utilities', () => {
 
       const result = loadCache('test-workspace', deps);
 
-      expect(result).toEqual(['doc1', 'doc2', 'doc3']);
+      expect(result).toEqual(documents);
     });
 
     it('returns null when workspace is not in cache', () => {
       const cacheContent = JSON.stringify({
         'other-workspace': {
-          slugs: ['doc1'],
+          documents: [{ slug: 'doc1', title: 'Doc 1' }],
           timestamp: 1000000,
           workspace: 'other-workspace',
         },
@@ -209,10 +218,38 @@ describe('cache utilities', () => {
 
       expect(result).toBeNull();
     });
+
+    it('returns null when cache is in old format (backward compatibility)', () => {
+      const cacheContent = JSON.stringify({
+        'test-workspace': {
+          slugs: ['doc1', 'doc2'],
+          timestamp: 1000000,
+          workspace: 'test-workspace',
+        },
+      });
+
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          readFile: vi.fn(() => cacheContent),
+          access: vi.fn(),
+        },
+        now: mockNow,
+      };
+
+      const result = loadCache('test-workspace', deps);
+
+      expect(result).toBeNull();
+    });
   });
 
   describe('saveCache', () => {
     it('creates cache directory if it does not exist', async () => {
+      const documents: DocumentCacheItem[] = [
+        { slug: 'doc1', title: 'Doc 1' },
+        { slug: 'doc2', title: 'Doc 2' },
+      ];
+
       const deps: Partial<CacheDeps> = {
         fsApi: {
           ...mockFsApi,
@@ -228,7 +265,7 @@ describe('cache utilities', () => {
         now: mockNow,
       };
 
-      await saveCache('test-workspace', ['doc1', 'doc2'], deps);
+      await saveCache('test-workspace', documents, deps);
 
       expect(deps.fsApi!.mkdir).toHaveBeenCalledWith(expect.stringContaining('hackersheet'), {
         recursive: true,
@@ -237,6 +274,11 @@ describe('cache utilities', () => {
 
     it('writes cache file with correct structure', async () => {
       let writtenContent = '';
+
+      const documents: DocumentCacheItem[] = [
+        { slug: 'doc1', title: 'Doc 1' },
+        { slug: 'doc2', title: 'Doc 2' },
+      ];
 
       const deps: Partial<CacheDeps> = {
         fsApi: {
@@ -255,25 +297,27 @@ describe('cache utilities', () => {
         now: vi.fn(() => 2000000),
       };
 
-      await saveCache('test-workspace', ['doc1', 'doc2'], deps);
+      await saveCache('test-workspace', documents, deps);
 
       const parsed = JSON.parse(writtenContent);
       expect(parsed['test-workspace']).toEqual({
-        slugs: ['doc1', 'doc2'],
+        documents,
         timestamp: 2000000,
         workspace: 'test-workspace',
       });
     });
 
     it('preserves existing cache entries for other workspaces', async () => {
+      const existingDocs: DocumentCacheItem[] = [{ slug: 'existing-doc', title: 'Existing Doc' }];
       const existingCache = JSON.stringify({
         'other-workspace': {
-          slugs: ['existing-doc'],
+          documents: existingDocs,
           timestamp: 1000,
           workspace: 'other-workspace',
         },
       });
 
+      const newDocs: DocumentCacheItem[] = [{ slug: 'new-doc', title: 'New Doc' }];
       let writtenContent = '';
 
       const deps: Partial<CacheDeps> = {
@@ -289,16 +333,16 @@ describe('cache utilities', () => {
         now: vi.fn(() => 2000000),
       };
 
-      await saveCache('test-workspace', ['new-doc'], deps);
+      await saveCache('test-workspace', newDocs, deps);
 
       const parsed = JSON.parse(writtenContent);
       expect(parsed['other-workspace']).toEqual({
-        slugs: ['existing-doc'],
+        documents: existingDocs,
         timestamp: 1000,
         workspace: 'other-workspace',
       });
       expect(parsed['test-workspace']).toEqual({
-        slugs: ['new-doc'],
+        documents: newDocs,
         timestamp: 2000000,
         workspace: 'test-workspace',
       });

--- a/packages/cli/src/utils/__tests__/cache.unit.test.ts
+++ b/packages/cli/src/utils/__tests__/cache.unit.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import {
+  loadCache,
+  saveCache,
+  clearCache,
+  getCacheDir,
+  getCachePath,
+  isCacheValid,
+  type CacheDeps,
+  type SlugsCacheEntry,
+} from '../cache';
+
+describe('cache utilities', () => {
+  let mockFsApi: CacheDeps['fsApi'];
+  let mockNow: () => number;
+
+  beforeEach(() => {
+    mockFsApi = {
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+      unlink: vi.fn(),
+      access: vi.fn(),
+    };
+    mockNow = vi.fn(() => 1000000);
+  });
+
+  describe('getCacheDir', () => {
+    it('returns XDG_CACHE_HOME/hackersheet when XDG_CACHE_HOME is set', () => {
+      const oldEnv = process.env.XDG_CACHE_HOME;
+      process.env.XDG_CACHE_HOME = '/custom/cache';
+
+      const result = getCacheDir();
+
+      expect(result).toBe('/custom/cache/hackersheet');
+
+      if (oldEnv) {
+        process.env.XDG_CACHE_HOME = oldEnv;
+      } else {
+        delete process.env.XDG_CACHE_HOME;
+      }
+    });
+
+    it('returns ~/.cache/hackersheet when XDG_CACHE_HOME is not set', () => {
+      const oldEnv = process.env.XDG_CACHE_HOME;
+      delete process.env.XDG_CACHE_HOME;
+
+      const result = getCacheDir();
+
+      expect(result).toMatch(/\.cache\/hackersheet$/);
+
+      if (oldEnv) {
+        process.env.XDG_CACHE_HOME = oldEnv;
+      }
+    });
+  });
+
+  describe('getCachePath', () => {
+    it('returns path ending with slugs-cache.json', () => {
+      const result = getCachePath();
+      expect(result).toMatch(/slugs-cache\.json$/);
+    });
+  });
+
+  describe('isCacheValid', () => {
+    it('returns true if cache is within TTL', () => {
+      const entry: SlugsCacheEntry = {
+        slugs: ['doc1'],
+        timestamp: 1000,
+        workspace: 'test-workspace',
+      };
+      const ttl = 1000000;
+      const now = 1500; // 500ms later
+
+      const result = isCacheValid(entry, ttl, now);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false if cache is expired', () => {
+      const entry: SlugsCacheEntry = {
+        slugs: ['doc1'],
+        timestamp: 1000,
+        workspace: 'test-workspace',
+      };
+      const ttl = 1000;
+      const now = 3000; // 2000ms later, exceeds TTL
+
+      const result = isCacheValid(entry, ttl, now);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true if cache timestamp equals now - ttl', () => {
+      const entry: SlugsCacheEntry = {
+        slugs: ['doc1'],
+        timestamp: 0,
+        workspace: 'test-workspace',
+      };
+      const ttl = 1000;
+      const now = 999; // Just before expiry
+
+      const result = isCacheValid(entry, ttl, now);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('loadCache', () => {
+    it('returns null when cache file does not exist', () => {
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          access: vi.fn(() => {
+            throw new Error('File not found');
+          }),
+        },
+        now: mockNow,
+      };
+
+      const result = loadCache('test-workspace', deps);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when cache is expired', () => {
+      const oldTimestamp = 1000;
+      const cacheContent = JSON.stringify({
+        'test-workspace': {
+          slugs: ['doc1', 'doc2'],
+          timestamp: oldTimestamp,
+          workspace: 'test-workspace',
+        },
+      });
+
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          readFile: vi.fn(() => cacheContent),
+          access: vi.fn(),
+        },
+        now: vi.fn(() => oldTimestamp + 25 * 60 * 60 * 1000), // 25 hours later
+      };
+
+      const result = loadCache('test-workspace', deps);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns cached slugs when cache is valid', () => {
+      const timestamp = 1000000;
+      const cacheContent = JSON.stringify({
+        'test-workspace': {
+          slugs: ['doc1', 'doc2', 'doc3'],
+          timestamp,
+          workspace: 'test-workspace',
+        },
+      });
+
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          readFile: vi.fn(() => cacheContent),
+          access: vi.fn(),
+        },
+        now: vi.fn(() => timestamp + 1000), // 1 second later
+      };
+
+      const result = loadCache('test-workspace', deps);
+
+      expect(result).toEqual(['doc1', 'doc2', 'doc3']);
+    });
+
+    it('returns null when workspace is not in cache', () => {
+      const cacheContent = JSON.stringify({
+        'other-workspace': {
+          slugs: ['doc1'],
+          timestamp: 1000000,
+          workspace: 'other-workspace',
+        },
+      });
+
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          readFile: vi.fn(() => cacheContent),
+          access: vi.fn(),
+        },
+        now: mockNow,
+      };
+
+      const result = loadCache('test-workspace', deps);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when cache file is invalid JSON', () => {
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          readFile: vi.fn(() => 'invalid json'),
+          access: vi.fn(),
+        },
+        now: mockNow,
+      };
+
+      const result = loadCache('test-workspace', deps);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('saveCache', () => {
+    it('creates cache directory if it does not exist', async () => {
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          mkdir: vi.fn(),
+          writeFile: vi.fn(),
+          readFile: vi.fn(() => {
+            throw new Error('File not found');
+          }),
+          access: vi.fn(() => {
+            throw new Error('File not found');
+          }),
+        },
+        now: mockNow,
+      };
+
+      await saveCache('test-workspace', ['doc1', 'doc2'], deps);
+
+      expect(deps.fsApi!.mkdir).toHaveBeenCalledWith(expect.stringContaining('hackersheet'), {
+        recursive: true,
+      });
+    });
+
+    it('writes cache file with correct structure', async () => {
+      let writtenContent = '';
+
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          mkdir: vi.fn(),
+          writeFile: vi.fn((_path: string, data: string) => {
+            writtenContent = data;
+          }),
+          readFile: vi.fn(() => {
+            throw new Error('File not found');
+          }),
+          access: vi.fn(() => {
+            throw new Error('File not found');
+          }),
+        },
+        now: vi.fn(() => 2000000),
+      };
+
+      await saveCache('test-workspace', ['doc1', 'doc2'], deps);
+
+      const parsed = JSON.parse(writtenContent);
+      expect(parsed['test-workspace']).toEqual({
+        slugs: ['doc1', 'doc2'],
+        timestamp: 2000000,
+        workspace: 'test-workspace',
+      });
+    });
+
+    it('preserves existing cache entries for other workspaces', async () => {
+      const existingCache = JSON.stringify({
+        'other-workspace': {
+          slugs: ['existing-doc'],
+          timestamp: 1000,
+          workspace: 'other-workspace',
+        },
+      });
+
+      let writtenContent = '';
+
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          mkdir: vi.fn(),
+          writeFile: vi.fn((_path: string, data: string) => {
+            writtenContent = data;
+          }),
+          readFile: vi.fn(() => existingCache),
+          access: vi.fn(),
+        },
+        now: vi.fn(() => 2000000),
+      };
+
+      await saveCache('test-workspace', ['new-doc'], deps);
+
+      const parsed = JSON.parse(writtenContent);
+      expect(parsed['other-workspace']).toEqual({
+        slugs: ['existing-doc'],
+        timestamp: 1000,
+        workspace: 'other-workspace',
+      });
+      expect(parsed['test-workspace']).toEqual({
+        slugs: ['new-doc'],
+        timestamp: 2000000,
+        workspace: 'test-workspace',
+      });
+    });
+  });
+
+  describe('clearCache', () => {
+    it('deletes cache file if it exists', async () => {
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          access: vi.fn(),
+          unlink: vi.fn(),
+        },
+      };
+
+      await clearCache(deps);
+
+      expect(deps.fsApi!.unlink).toHaveBeenCalledWith(expect.stringContaining('slugs-cache.json'));
+    });
+
+    it('does not throw error if cache file does not exist', async () => {
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          access: vi.fn(() => {
+            throw new Error('File not found');
+          }),
+        },
+      };
+
+      await expect(clearCache(deps)).resolves.toBeUndefined();
+    });
+
+    it('silently handles errors during deletion', async () => {
+      const deps: Partial<CacheDeps> = {
+        fsApi: {
+          ...mockFsApi,
+          access: vi.fn(),
+          unlink: vi.fn(() => {
+            throw new Error('Permission denied');
+          }),
+        },
+      };
+
+      await expect(clearCache(deps)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/utils/__tests__/cache.unit.test.ts
+++ b/packages/cli/src/utils/__tests__/cache.unit.test.ts
@@ -7,9 +7,14 @@ import {
   getCacheDir,
   getCachePath,
   isCacheValid,
+  loadDocumentCache,
+  saveDocumentCache,
+  clearDocumentsCache,
+  getDocumentsCacheDir,
   type CacheDeps,
   type DocumentsCacheEntry,
   type DocumentCacheItem,
+  type CachedDocument,
 } from '../cache';
 
 describe('cache utilities', () => {
@@ -389,6 +394,46 @@ describe('cache utilities', () => {
       };
 
       await expect(clearCache(deps)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getDocumentsCacheDir', () => {
+    it('returns correct path for workspace documents', () => {
+      const result = getDocumentsCacheDir('workspace-1');
+      expect(result).toMatch(/documents[/\\]workspace-1$/);
+    });
+  });
+
+  describe('loadDocumentCache', () => {
+    it('returns null when file does not exist (integration test)', () => {
+      // This is a light integration test that verifies the function handles missing files gracefully
+      const result = loadDocumentCache('nonexistent-workspace-12345', 'nonexistent-doc-12345');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('saveDocumentCache', () => {
+    it('silently fails when cache dir is not writable (integration test)', async () => {
+      // This test verifies that saveDocumentCache handles errors gracefully
+      // even if directory is not writable (we don't actually test writing)
+      const document: CachedDocument = {
+        id: 'doc-123',
+        slug: 'test-doc',
+        title: 'Test Document',
+        content: 'This is test content',
+        draft: false,
+      };
+
+      // This should not throw even if there are fs errors
+      await expect(saveDocumentCache('workspace-1', 'test-doc', document)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearDocumentsCache', () => {
+    it('silently handles errors when documents directory does not exist', async () => {
+      // This test verifies that clearDocumentsCache handles missing directories gracefully
+      await expect(clearDocumentsCache()).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/cli/src/utils/cache.ts
+++ b/packages/cli/src/utils/cache.ts
@@ -1,0 +1,200 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+/**
+ * Represents a single cache entry for a workspace.
+ */
+export type SlugsCacheEntry = {
+  slugs: string[];
+  timestamp: number;
+  workspace: string;
+};
+
+/**
+ * Represents the entire cache structure.
+ */
+export type SlugsCache = Record<string, SlugsCacheEntry>;
+
+/**
+ * Dependencies for cache operations (for testing).
+ */
+export type CacheDeps = {
+  fsApi: {
+    readFile: (path: string, encoding: string) => string;
+    writeFile: (path: string, data: string) => void;
+    mkdir: (path: string, options?: { recursive?: boolean }) => void;
+    unlink: (path: string) => void;
+    access: (path: string) => void;
+  };
+  now: () => number;
+};
+
+/**
+ * Get the cache directory path following XDG Base Directory spec.
+ * Falls back to ~/.cache/hackersheet if XDG_CACHE_HOME is not set.
+ *
+ * @returns The cache directory path.
+ */
+export function getCacheDir(): string {
+  const xdgCacheHome = process.env.XDG_CACHE_HOME;
+  const home = os.homedir();
+
+  if (xdgCacheHome) {
+    return path.join(xdgCacheHome, 'hackersheet');
+  }
+
+  return path.join(home, '.cache', 'hackersheet');
+}
+
+/**
+ * Get the full path to the slugs cache file.
+ *
+ * @returns The cache file path.
+ */
+export function getCachePath(): string {
+  return path.join(getCacheDir(), 'slugs-cache.json');
+}
+
+/**
+ * Check if a cache entry is still valid based on TTL.
+ *
+ * @param entry - The cache entry to validate.
+ * @param ttl - Time to live in milliseconds.
+ * @param now - Current timestamp in milliseconds.
+ * @returns True if the cache entry is still valid.
+ */
+export function isCacheValid(entry: SlugsCacheEntry, ttl: number, now: number): boolean {
+  return now - entry.timestamp < ttl;
+}
+
+/**
+ * Load slugs from cache for a specific workspace.
+ * Returns null if cache is missing, expired, or invalid.
+ *
+ * @param workspace - The workspace slug.
+ * @param deps - Optional dependencies for testing.
+ * @returns Array of slugs if cache is valid, null otherwise.
+ */
+export function loadCache(workspace: string, deps?: Partial<CacheDeps>): string[] | null {
+  const cachePath = getCachePath();
+  const { fsApi, now } = {
+    fsApi: {
+      readFile: (filePath: string, encoding: string) =>
+        fs.readFileSync(filePath, encoding as BufferEncoding),
+      writeFile: (filePath: string, data: string) => fs.writeFileSync(filePath, data, 'utf8'),
+      mkdir: (filePath: string, options?: { recursive?: boolean }) => fs.mkdirSync(filePath, options),
+      unlink: (filePath: string) => fs.unlinkSync(filePath),
+      access: (filePath: string) => fs.accessSync(filePath),
+    },
+    now: () => Date.now(),
+    ...deps,
+  };
+
+  try {
+    fsApi.access(cachePath);
+  } catch {
+    return null;
+  }
+
+  try {
+    const content = fsApi.readFile(cachePath, 'utf8');
+    const cache: SlugsCache = JSON.parse(content);
+
+    const entry = cache[workspace];
+    if (!entry) {
+      return null;
+    }
+
+    if (!isCacheValid(entry, DEFAULT_TTL, now())) {
+      return null;
+    }
+
+    return entry.slugs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save slugs to cache for a specific workspace.
+ *
+ * @param workspace - The workspace slug.
+ * @param slugs - Array of document slugs to cache.
+ * @param deps - Optional dependencies for testing.
+ */
+export async function saveCache(workspace: string, slugs: string[], deps?: Partial<CacheDeps>): Promise<void> {
+  const cachePath = getCachePath();
+  const cacheDir = getCacheDir();
+  const { fsApi, now } = {
+    fsApi: {
+      readFile: (filePath: string, encoding: string) =>
+        fs.readFileSync(filePath, encoding as BufferEncoding),
+      writeFile: (filePath: string, data: string) => fs.writeFileSync(filePath, data, 'utf8'),
+      mkdir: (filePath: string, options?: { recursive?: boolean }) => fs.mkdirSync(filePath, options),
+      unlink: (filePath: string) => fs.unlinkSync(filePath),
+      access: (filePath: string) => fs.accessSync(filePath),
+    },
+    now: () => Date.now(),
+    ...deps,
+  };
+
+  try {
+    fsApi.mkdir(cacheDir, { recursive: true });
+  } catch {
+    // Directory creation failed, silently continue
+    return;
+  }
+
+  try {
+    let cache: SlugsCache = {};
+
+    try {
+      fsApi.access(cachePath);
+      const content = fsApi.readFile(cachePath, 'utf8');
+      cache = JSON.parse(content);
+    } catch {
+      // Cache file doesn't exist or is invalid, start fresh
+      cache = {};
+    }
+
+    cache[workspace] = {
+      slugs,
+      timestamp: now(),
+      workspace,
+    };
+
+    fsApi.writeFile(cachePath, JSON.stringify(cache));
+  } catch {
+    // Silently fail if we can't write to cache
+  }
+}
+
+/**
+ * Clear the entire cache file.
+ *
+ * @param deps - Optional dependencies for testing.
+ */
+export async function clearCache(deps?: Partial<CacheDeps>): Promise<void> {
+  const cachePath = getCachePath();
+  const { fsApi } = {
+    fsApi: {
+      readFile: (filePath: string, encoding: string) =>
+        fs.readFileSync(filePath, encoding as BufferEncoding),
+      writeFile: (filePath: string, data: string) => fs.writeFileSync(filePath, data, 'utf8'),
+      mkdir: (filePath: string, options?: { recursive?: boolean }) => fs.mkdirSync(filePath, options),
+      unlink: (filePath: string) => fs.unlinkSync(filePath),
+      access: (filePath: string) => fs.accessSync(filePath),
+    },
+    ...deps,
+  };
+
+  try {
+    fsApi.access(cachePath);
+    fsApi.unlink(cachePath);
+  } catch {
+    // File doesn't exist or can't be deleted, ignore
+  }
+}

--- a/packages/cli/src/utils/cache.ts
+++ b/packages/cli/src/utils/cache.ts
@@ -214,3 +214,80 @@ export async function clearCache(deps?: Partial<CacheDeps>): Promise<void> {
     // File doesn't exist or can't be deleted, ignore
   }
 }
+
+/**
+ * Represents a cached document with full content.
+ */
+export type CachedDocument = {
+  id: string;
+  slug: string;
+  title: string;
+  content: string;
+  draft: boolean;
+  [key: string]: unknown;
+};
+
+/**
+ * Get the directory path for cached documents.
+ *
+ * @param workspace - The workspace slug.
+ * @returns The documents cache directory path.
+ */
+export function getDocumentsCacheDir(workspace: string): string {
+  return path.join(getCacheDir(), 'documents', workspace);
+}
+
+/**
+ * Load a document from cache by slug.
+ *
+ * @param workspace - The workspace slug.
+ * @param slug - The document slug.
+ * @returns The cached document if found, null otherwise.
+ */
+export function loadDocumentCache(workspace: string, slug: string): CachedDocument | null {
+  const cacheDir = getDocumentsCacheDir(workspace);
+  const cacheFile = path.join(cacheDir, `${slug}.json`);
+
+  try {
+    const content = fs.readFileSync(cacheFile, 'utf8');
+    return JSON.parse(content) as CachedDocument;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a document to cache by slug.
+ *
+ * @param workspace - The workspace slug.
+ * @param slug - The document slug.
+ * @param document - The document to cache.
+ */
+export async function saveDocumentCache(workspace: string, slug: string, document: CachedDocument): Promise<void> {
+  const cacheDir = getDocumentsCacheDir(workspace);
+
+  try {
+    await fs.promises.mkdir(cacheDir, { recursive: true });
+    const cacheFile = path.join(cacheDir, `${slug}.json`);
+    await fs.promises.writeFile(cacheFile, JSON.stringify(document, null, 2), 'utf8');
+  } catch {
+    // Silently fail if we can't write to cache
+  }
+}
+
+/**
+ * Clear the documents cache directory for all workspaces.
+ */
+export async function clearDocumentsCache(): Promise<void> {
+  const cacheDir = getCacheDir();
+  const documentsDir = path.join(cacheDir, 'documents');
+
+  try {
+    // Recursively remove the entire documents directory
+    if (fs.existsSync(documentsDir)) {
+      fs.rmSync(documentsDir, { recursive: true, force: true });
+    }
+  } catch {
+    // Directory doesn't exist or can't be deleted, ignore
+  }
+}

--- a/packages/cli/src/utils/cache.ts
+++ b/packages/cli/src/utils/cache.ts
@@ -5,10 +5,20 @@ import path from 'path';
 const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 
 /**
+ * A single document entry in the cache.
+ */
+export type DocumentCacheItem = {
+  /** Document slug. */
+  slug: string;
+  /** Document title. */
+  title: string;
+};
+
+/**
  * Represents a single cache entry for a workspace.
  */
-export type SlugsCacheEntry = {
-  slugs: string[];
+export type DocumentsCacheEntry = {
+  documents: DocumentCacheItem[];
   timestamp: number;
   workspace: string;
 };
@@ -16,7 +26,7 @@ export type SlugsCacheEntry = {
 /**
  * Represents the entire cache structure.
  */
-export type SlugsCache = Record<string, SlugsCacheEntry>;
+export type DocumentsCache = Record<string, DocumentsCacheEntry>;
 
 /**
  * Dependencies for cache operations (for testing).
@@ -66,24 +76,23 @@ export function getCachePath(): string {
  * @param now - Current timestamp in milliseconds.
  * @returns True if the cache entry is still valid.
  */
-export function isCacheValid(entry: SlugsCacheEntry, ttl: number, now: number): boolean {
+export function isCacheValid(entry: DocumentsCacheEntry, ttl: number, now: number): boolean {
   return now - entry.timestamp < ttl;
 }
 
 /**
- * Load slugs from cache for a specific workspace.
- * Returns null if cache is missing, expired, or invalid.
+ * Load documents from cache for a specific workspace.
+ * Returns null if cache is missing, expired, invalid, or in old format.
  *
  * @param workspace - The workspace slug.
  * @param deps - Optional dependencies for testing.
- * @returns Array of slugs if cache is valid, null otherwise.
+ * @returns Array of documents if cache is valid, null otherwise.
  */
-export function loadCache(workspace: string, deps?: Partial<CacheDeps>): string[] | null {
+export function loadCache(workspace: string, deps?: Partial<CacheDeps>): DocumentCacheItem[] | null {
   const cachePath = getCachePath();
   const { fsApi, now } = {
     fsApi: {
-      readFile: (filePath: string, encoding: string) =>
-        fs.readFileSync(filePath, encoding as BufferEncoding),
+      readFile: (filePath: string, encoding: string) => fs.readFileSync(filePath, encoding as BufferEncoding),
       writeFile: (filePath: string, data: string) => fs.writeFileSync(filePath, data, 'utf8'),
       mkdir: (filePath: string, options?: { recursive?: boolean }) => fs.mkdirSync(filePath, options),
       unlink: (filePath: string) => fs.unlinkSync(filePath),
@@ -101,10 +110,15 @@ export function loadCache(workspace: string, deps?: Partial<CacheDeps>): string[
 
   try {
     const content = fsApi.readFile(cachePath, 'utf8');
-    const cache: SlugsCache = JSON.parse(content);
+    const cache: DocumentsCache = JSON.parse(content);
 
     const entry = cache[workspace];
     if (!entry) {
+      return null;
+    }
+
+    // Backward compatibility: old cache format had "slugs" field instead of "documents"
+    if ('slugs' in (entry as unknown as Record<string, unknown>) && !('documents' in entry)) {
       return null;
     }
 
@@ -112,26 +126,29 @@ export function loadCache(workspace: string, deps?: Partial<CacheDeps>): string[
       return null;
     }
 
-    return entry.slugs;
+    return entry.documents;
   } catch {
     return null;
   }
 }
 
 /**
- * Save slugs to cache for a specific workspace.
+ * Save documents to cache for a specific workspace.
  *
  * @param workspace - The workspace slug.
- * @param slugs - Array of document slugs to cache.
+ * @param documents - Array of documents to cache.
  * @param deps - Optional dependencies for testing.
  */
-export async function saveCache(workspace: string, slugs: string[], deps?: Partial<CacheDeps>): Promise<void> {
+export async function saveCache(
+  workspace: string,
+  documents: DocumentCacheItem[],
+  deps?: Partial<CacheDeps>
+): Promise<void> {
   const cachePath = getCachePath();
   const cacheDir = getCacheDir();
   const { fsApi, now } = {
     fsApi: {
-      readFile: (filePath: string, encoding: string) =>
-        fs.readFileSync(filePath, encoding as BufferEncoding),
+      readFile: (filePath: string, encoding: string) => fs.readFileSync(filePath, encoding as BufferEncoding),
       writeFile: (filePath: string, data: string) => fs.writeFileSync(filePath, data, 'utf8'),
       mkdir: (filePath: string, options?: { recursive?: boolean }) => fs.mkdirSync(filePath, options),
       unlink: (filePath: string) => fs.unlinkSync(filePath),
@@ -149,7 +166,7 @@ export async function saveCache(workspace: string, slugs: string[], deps?: Parti
   }
 
   try {
-    let cache: SlugsCache = {};
+    let cache: DocumentsCache = {};
 
     try {
       fsApi.access(cachePath);
@@ -161,12 +178,12 @@ export async function saveCache(workspace: string, slugs: string[], deps?: Parti
     }
 
     cache[workspace] = {
-      slugs,
+      documents,
       timestamp: now(),
       workspace,
     };
 
-    fsApi.writeFile(cachePath, JSON.stringify(cache));
+    fsApi.writeFile(cachePath, JSON.stringify(cache, null, 2));
   } catch {
     // Silently fail if we can't write to cache
   }
@@ -181,8 +198,7 @@ export async function clearCache(deps?: Partial<CacheDeps>): Promise<void> {
   const cachePath = getCachePath();
   const { fsApi } = {
     fsApi: {
-      readFile: (filePath: string, encoding: string) =>
-        fs.readFileSync(filePath, encoding as BufferEncoding),
+      readFile: (filePath: string, encoding: string) => fs.readFileSync(filePath, encoding as BufferEncoding),
       writeFile: (filePath: string, data: string) => fs.writeFileSync(filePath, data, 'utf8'),
       mkdir: (filePath: string, options?: { recursive?: boolean }) => fs.mkdirSync(filePath, options),
       unlink: (filePath: string) => fs.unlinkSync(filePath),

--- a/packages/cli/test-completion-e2e.mjs
+++ b/packages/cli/test-completion-e2e.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.join(__dirname, 'dist', 'cli.mjs');
+
+/**
+ * Test completion with environment variables
+ */
+async function testCompletion(name, env) {
+  return new Promise((resolve) => {
+    const output = [];
+    const proc = spawn('node', [cliPath], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    proc.stdout.on('data', (data) => {
+      output.push(data.toString().trim());
+    });
+
+    proc.on('close', () => {
+      console.log(`\n📋 Test: ${name}`);
+      console.log(`   Environment: COMP_CWORD=${env.COMP_CWORD}, COMP_LINE="${env.COMP_LINE}"`);
+      console.log(`   Output:`);
+      output.forEach((line) => {
+        if (line) console.log(`     ${line}`);
+      });
+      resolve();
+    });
+  });
+}
+
+/**
+ * Run all completion tests
+ */
+async function runTests() {
+  console.log('🧪 Shell Completion E2E Tests\n');
+  console.log('='.repeat(50));
+
+  // Test 1: Default command completion
+  await testCompletion('Default command completion', {
+    COMP_CWORD: '1',
+    COMP_LINE: 'hscli ',
+    COMP_POINT: '6',
+  });
+
+  // Test 2: docs command completion (without workspace config)
+  await testCompletion('docs command completion (no workspace)', {
+    COMP_CWORD: '2',
+    COMP_LINE: 'hscli docs ',
+    COMP_POINT: '11',
+  });
+
+  // Test 3: Command with partial input
+  await testCompletion('Partial command completion', {
+    COMP_CWORD: '1',
+    COMP_LINE: 'hscli c',
+    COMP_POINT: '7',
+  });
+
+  // Test 4: Workspace option completion
+  await testCompletion('Workspace option completion', {
+    COMP_CWORD: '3',
+    COMP_LINE: 'hscli docs -w ',
+    COMP_POINT: '14',
+  });
+
+  console.log('\n' + '='.repeat(50));
+  console.log('✅ All tests completed\n');
+}
+
+runTests().catch(console.error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@inquirer/prompts':
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.9)
+      '@pnpm/tabtab':
+        specifier: ^0.1.0
+        version: 0.1.2
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -1858,6 +1861,10 @@ packages:
   '@parcel/watcher@2.5.1':
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
+
+  '@pnpm/tabtab@0.1.2':
+    resolution: {integrity: sha512-AYg+Vir0D0rigS9/O7M+v80J4WpTbl68pElNIQ9K5IYxfJ5h3Zk0NJI7bVciV/xbHj3SalmaE6Il8GbPOlKo7g==}
+    engines: {node: '>=10'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -5373,6 +5380,10 @@ packages:
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
+  untildify@4.0.0:
+    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
+    engines: {node: '>=8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -7164,6 +7175,15 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
     optional: true
+
+  '@pnpm/tabtab@0.1.2':
+    dependencies:
+      debug: 4.4.3
+      enquirer: 2.4.1
+      minimist: 1.2.8
+      untildify: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -11251,6 +11271,8 @@ snapshots:
       normalize-path: 2.1.1
 
   until-async@3.0.2: {}
+
+  untildify@4.0.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:


### PR DESCRIPTION
## Summary

Implement a comprehensive shell tab completion system with document content caching for the Hacker Sheet CLI. This PR includes 12 commits that deliver major improvements to the CLI user experience, including:

- Complete shell tab completion system (bash/zsh/fish)
- Setup/Init command separation with global vs project configuration
- Document content caching with ~4.7x performance improvement
- Docs command refactoring (list/show subcommands)
- Configuration path display with cache directory support

## Changes

### Shell Tab Completion System
- Document slug and title autocomplete for `docs show <TAB>`
- All subcommand completion (docs, config, completion, cache)
- Cursor-based pagination for large document sets (100+)
- Metadata cache in ~/.cache/hackersheet/slugs-cache.json
- Workspace auto-detection with -w/--workspace option

### Setup/Init Command Separation
- `hscli setup`: Global configuration (workspace authentication)
- `hscli init`: Project configuration (directories, templates)
- Mode-based wizard with ConfigWizardMode('global', 'project', 'all')
- Clear prerequisite validation with helpful error messages
- Git-inspired --global/--local pattern

### Document Content Caching
- Persistent file-based cache: ~/.cache/hackersheet/documents/{workspace}/{slug}.json
- Complete document metadata: id, slug, title, content, draft status
- `--refresh` flag to bypass cache and fetch latest
- ~4.7x performance improvement (0.093s vs 0.436s from cache)
- Integrated into cache clear command

### Docs Command Refactoring
- `docs list`: Display all documents with pagination
- `docs show <slug>`: Show document content by slug
- Improved CLI consistency

### Cache Directory Path Display
- `config path`: Show config and cache paths
- `-g/--global`, `-l/--local`, `-c/--cache` flags for specific paths
- XDG Base Directory Specification compliance

## Type of Change

- Feature: Shell completion system
- Feature: Document content caching
- Feature: Setup/Init command separation
- Enhancement: Docs command refactoring
- Enhancement: Configuration path display

## Testing

- 370 tests passing (increased from 233)
- New test file: docs-show-action.unit.test.ts (14 tests)
- Expanded cache utility tests (12 new tests)
- Full TypeScript and ESLint compliance
- Real-world testing: Successfully caches and retrieves documents

## Related Issues

None

## Commits Included

1. feat(cli): add shell tab completion support
2. refactor(cli): clean up shell completion code and improve type safety
3. feat(cli): implement shell completion with document title support
4. fix(cli): implement cursor-based pagination for fetching all documents
5. feat(cli): refactor docs command with list and show subcommands
6. fix(cli): fix shell completion to only trigger on docs show subcommand
7. feat(cli): add docs subcommand completion suggestions
8. feat(cli): separate setup and init commands with mode-based wizard
9. feat(cli): add cache directory path to config path command
10. refactor(cli): enhance shell completion with all subcommands
11. feat(cli): implement document content caching for docs show command
12. chore: add changeset for document content caching feature